### PR TITLE
Update javascript-quickstart.mdx - Fixing a link

### DIFF
--- a/pages/docs/tracking/javascript-quickstart.mdx
+++ b/pages/docs/tracking/javascript-quickstart.mdx
@@ -50,7 +50,7 @@ mixpanel.track('Signed Up', {
 })
 ```
 
-🎉 Congratulations, you've tracked your first event! You can see it in Mixpanel via the [Events page](mixpanel.com/report/events). For more options, see our [JavaScript reference](/tracking/advanced/javascript).
+🎉 Congratulations, you've tracked your first event! You can see it in Mixpanel via the [Events page](https://mixpanel.com/report/events). For more options, see our [JavaScript reference](/tracking/advanced/javascript).
         
         
 You can also follow our video walkthrough [here](https://www.loom.com/embed/fbba03274dc441b49b578e8a734b1d99).


### PR DESCRIPTION
added https:// to mixpanel.com/report/events since the link is broken and tries to go to https://docs-mixpanel.vercel.app/docs/tracking/mixpanel.com/report/events instead