### PR TITLE
fix zendesk artifacts

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,12 @@ const withNextra = require("nextra")({
 });
 
 function parseRedirectPartsFromFile(filecontent) {
-  return filecontent.trim().split(`\n`).map((line, idx) => {
+  const rawRedirects = filecontent
+    .split(`\n`)
+    .filter((line) => line.trim() !== ``) // Ignore empty lines
+    .filter((line) => !line.startsWith(`#`)); // Ignore comments
+
+  return rawRedirects.map((line, idx) => {
     const parts = line.split(` `);
     if (parts.length !== 2) {
       throw Error(

--- a/redirects/help-mixpanel-com.txt
+++ b/redirects/help-mixpanel-com.txt
@@ -1,4 +1,5 @@
 https://help.mixpanel.com/ /
+https://help.mixpanel.com/:zendesk_attachment(attachments/token/.*) https://mixpanelsupport.zendesk.com/:zendesk_attachment
 https://help.mixpanel.com/docs/search /docs/getting-started/what-is-mixpanel
 https://help.mixpanel.com/hc docs/getting-started/what-is-mixpanel
 https://help.mixpanel.com/hc/admin/general_settings /docs/admin/organizations-projects

--- a/redirects/help-mixpanel-com.txt
+++ b/redirects/help-mixpanel-com.txt
@@ -1,9 +1,15 @@
+# Top Level Redirects. (No Sorting. Place with intention)
 https://help.mixpanel.com/ /
-https://help.mixpanel.com/:zendesk_attachment(attachments/token/.*) https://mixpanelsupport.zendesk.com/:zendesk_attachment
+https://help.mixpanel.com/hc/en-us /
 https://help.mixpanel.com/docs/search /docs/getting-started/what-is-mixpanel
+https://help.mixpanel.com/:path(docs.*) /:path
 https://help.mixpanel.com/hc docs/getting-started/what-is-mixpanel
 https://help.mixpanel.com/hc/admin/general_settings /docs/admin/organizations-projects
-https://help.mixpanel.com/hc/en-us /
+
+# send support attachments back to original source
+https://help.mixpanel.com/:zendesk_attachment(attachments/token/.*) https://mixpanelsupport.zendesk.com/:zendesk_attachment
+
+# Help Center - Content Redirects (Sort Alphabetically)
 https://help.mixpanel.com/hc/en-us/articles/10147279357076(.*) /docs/tracking/how-tos/debugging#data-discrepancies
 https://help.mixpanel.com/hc/en-us/articles/10503460589972(.*) /changelogs
 https://help.mixpanel.com/hc/en-us/articles/10997736335892(.*) https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md#mixpaneltime_event


### PR DESCRIPTION
Turns out zendesk was using our relative url for image uploads. So when support engineers were responding to tickets, the links had the host of help.mixpanel.com. This redirects puts attachments back to zendesk.