### PR TITLE
Increase GDPR limit for retrieval request

### DIFF
--- a/pages/docs/other-bits/privacy-and-security.md
+++ b/pages/docs/other-bits/privacy-and-security.md
@@ -55,7 +55,7 @@ Mixpanel deletion and retrieval APIs are in place to help Mixpanel implementatio
 
 
 > 📘GDPR Request Rate Limits
-> You can batch up to 2000 distinct IDs per deletion request and up to 100 for a retrieval request. Request rates are limited for GDPR API requests.
+> You can batch up to 2000 distinct IDs per deletion request and up to 2000 for a retrieval request. Request rates are limited for GDPR API requests.
 
 ### User Opt-Out
 While the following API can be used to delete or retrieve personal data as outlined by the GPDR, it is important to also opt users out of subsequent tracking. If tracking using a client-side Mixpanel library, you can opt users out of tracking using Mixpanel's opt-out methods. These are available in the following client-side libraries:
@@ -85,7 +85,7 @@ Parameters:
 | Parameter | Parameter Type | Data Type | Description |
 |-----------------|-------------------------|----------------|-------------------|
 | Token | URL. Passed in request URL. | Query String Parameter | Your Mixpanel [project token](/docs/admin/organizations-projects/manage-projects#find-your-project-tokens). |
-| distinct_ids | Body. Passed in JSON blob format. | Array of strings | A list of distinct IDs associated with the users whose data you would like to export. You can add up to 1999 distinct IDs. |
+| distinct_ids | Body. Passed in JSON blob format. | Array of strings | A list of distinct IDs associated with the users whose data you would like to export. You can add up to 2000 distinct IDs. |
 | compliance_type | Body. Passed in JSON blob format. | String | Select CCPA or GDPR. Default is GDPR. |
 | disclosure_type | Body. Passed in JSON blob format. | String | Only required if compliance_type = CCPA. Can be [Data, Categories, or Sources. Default is Data](/docs/other-bits/privacy-and-security/export-or-delete-end-user-data). |
 

--- a/pages/docs/other-bits/privacy-and-security/export-or-delete-end-user-data.md
+++ b/pages/docs/other-bits/privacy-and-security/export-or-delete-end-user-data.md
@@ -103,7 +103,7 @@ See Mixpanel’s [Privacy-Friendly Tracking](https://developer.mixpanel.com/docs
 Mixpanel deletion and retrieval APIs are in place to help Mixpanel implementations meet the requirements outlined by the General Data Protection Regulation (GDPR) legislation.
 
 > 📘GDPR Request Rate Limits
-> You can batch up to 2000 distinct IDs per deletion request and up to 100 for a retrieval request. Request rates are limited for GDPR API requests. 
+> You can batch up to 2000 distinct IDs per deletion request and up to 2000 for a retrieval request. Request rates are limited for GDPR API requests. 
 
 ### GDPR and CCPA API (v3)
 The following retrieval and deletion API calls are updated for version 3 and are made for GDPR and CCPA compliance. 
@@ -117,7 +117,7 @@ Parameters:
 | Parameter | Parameter Type | Data Type | Description |
 |-----------------|-------------------------|----------------|-------------------|
 | Token | URL. Passed in request URL. | Query String Parameter | Your Mixpanel [project token](/docs/admin/organizations-projects/manage-projects#find-your-project-tokens). |
-| distinct_ids | Body. Passed in JSON blob format. | Array of strings | A list of distinct IDs associated with the users whose data you would like to export. You can add up to 1999 distinct IDs. |
+| distinct_ids | Body. Passed in JSON blob format. | Array of strings | A list of distinct IDs associated with the users whose data you would like to export. You can add up to 2000 distinct IDs. |
 | compliance_type | Body. Passed in JSON blob format. | String | Select CCPA or GDPR. Default is GDPR. |
 | disclosure_type | Body. Passed in JSON blob format. | String | Only required if compliance_type = CCPA. Can be [Data, Categories, or Sources. Default is Data](/docs/other-bits/privacy-and-security/export-or-delete-end-user-data#ccpa-requests). |
 


### PR DESCRIPTION
Increase GDPR limit for retrieval request so that Noom can start sending requests to Mixpanel. 

Thread discussed: https://mixpanel.slack.com/archives/C04U70H63/p1684864264665889