### PR TITLE
Provide guidance on server-side tracking for marketing attribution

### DIFF
--- a/pages/docs/tracking/how-tos/effective-server.md
+++ b/pages/docs/tracking/how-tos/effective-server.md
@@ -27,7 +27,7 @@ mp = mixpanel.init("YOUR_TOKEN")
 
 def track_to_mp(request, event_name, properties):
   parsed = user_agent_parser.Parse(request.headers["User-Agent"])
-  
+
   # Set parsed values as properties.
   # You can also parse out the browser/device/os versions.
   properties.update({
@@ -37,14 +37,43 @@ def track_to_mp(request, event_name, properties):
   })
 
   properties["ip"] = request.remote_addr
-  mp.track(request.user_id, "Signed Up", properties)
+  mp.track(request.user_id, event_name, properties)
 
 def handle_signup(request):
   # ... logic to process the signup ...
 
   track_to_mp(request, "Signed Up", {"Signup Type": request.form["type"]})
-  
+
   return "Signup successful!"
+```
+
+## Tracking UTMs and Referrer
+Mixpanel's Web SDK parses UTM parameters from the current URL and obtains referrer information from the browser's `document.referrer` property to enable easy marketing analytics. Since this is not automatic for server-side implementations, these properties will need to be added manually to tracked events. Below is an example in Python:
+
+```python
+from urllib.parse import urlparse
+
+from mixpanel import Mixpanel
+
+mp = mixpanel.init("YOUR_TOKEN")
+
+def track_to_mp(request, event_name, properties):
+
+  # ... handle additional event properties such as $browser, $device, and $os ...
+
+  if "Referer" in request.headers:
+    properties.update({
+      "$referrer": request.headers["Referer"]
+      "$referring_domain": urlparse(request.headers["Referer"]).hostname
+    })
+
+  # assumes query parameters are available as Flask request.args dict
+  utm_keys = ["utm_source", "utm_medium", "utm_campaign", "utm_content", "utm_term"]
+  utm_values = {key: request.args[key] for key in utm_keys if request.args.get(key)}
+  properties.update(utm_values)
+
+  properties["ip"] = request.remote_addr
+  mp.track(request.user_id, event_name, properties)
 ```
 
 ## Tracking Geolocation
@@ -71,7 +100,7 @@ def handle_signup(request):
   # ... logic to process the signup ...
 
   track_to_mp(request, "Signed Up", {"Signup Type": request.form["type"]})
-  
+
   return "Signup successful!"
 ```
 
@@ -87,9 +116,9 @@ As an outline, you will want to follow the approach below:
 The key is to have an ID that is unique to each user and persists during that user's session. We recommend generating a UUID and storing that value in a cookie. All common server frameworks provide a simple way to set and retrieve cookies per request.
 
 ### Step 2: Leverage this ID for anonymous events
-When tracking events from your server, set the `distinct_id` property of events to the anonymous ID generated. 
+When tracking events from your server, set the `distinct_id` property of events to the anonymous ID generated.
 
-***In case your project has Simplied ID management specifically***, and the user is anonymous, you should include a property named `$device_id` with this value. You can then optionally also include the `distinct_id` (requires for you to prefix the ID with the string `'device:'`) but do note that if you don't include it, it will be assumed. You can see more in the python code example. 
+***In case your project has Simplied ID management specifically***, and the user is anonymous, you should include a property named `$device_id` with this value. You can then optionally also include the `distinct_id` (requires for you to prefix the ID with the string `'device:'`) but do note that if you don't include it, it will be assumed. You can see more in the python code example.
 
 ### Step 3: Set the authenticated ID once users log in
 
@@ -114,11 +143,11 @@ def track_to_mp(request, event_name, properties):
   # This assumes you've previously set a cookie called "session_id" that is local to the user's session
   # Set `$device_id` to that cookie's value
   properties["$device_id"] = uuid.uuid4()
-  
+
   # Set $user_id if the user is authenticated (logged in).
   if request.user.is_authenticated():
     properties["$user_id"] = request.user.username
-  
+
   # Note: leave the first argument blank here, since we're passing $device_id and $user_id as properties.
   mp.track("", event_name, properties)
 
@@ -129,9 +158,9 @@ def identify_user(request):
 
   }
   track_to_mp(request, "$identify", properties)
-  
+
 def handle_pageview(request):
   response = HTTPResponse("...")
-    
+
   track_to_mp(request, "Pageview", {"page_url": request.page_url})
 ```

--- a/pages/docs/tracking/how-tos/effective-server.md
+++ b/pages/docs/tracking/how-tos/effective-server.md
@@ -104,6 +104,14 @@ def handle_signup(request):
   return "Signup successful!"
 ```
 
+## Tracking Page Views
+Page view tracking must be done manually for server-side implementations. Here are some general guidelines for tracking page views.
+
+- Track page views as a single event type by using a constant `event_name`
+- Track different pages as an event property and not as different events for better analysis
+- Fire page view events only on successful responses to the client
+- Parse headers and the request URL for common web analytics properties such as referrer and UTM parameters
+  - See Mixpanel's [default web event properties](/docs/tracking/reference/default-properties#event-properties) for examples
 
 ## Identifying Users
 Our server libraries normally require that you specify the distinct_id value for each event. If you _don't_ know the user's identity at the time the event is tracked, then they're an anonymous user. When using our Web or Mobile SDKs, Mixpanel will automatically generate an ID that's local to that user's device. This ID will persist on all events tracked by that user on that device, until you call `identify()` or `reset()`. More on that in our [identity management guide](/docs/tracking/how-tos/identifying-users).
@@ -158,9 +166,4 @@ def identify_user(request):
 
   }
   track_to_mp(request, "$identify", properties)
-
-def handle_pageview(request):
-  response = HTTPResponse("...")
-
-  track_to_mp(request, "Pageview", {"page_url": request.page_url})
 ```

--- a/pages/docs/tracking/how-tos/effective-server.md
+++ b/pages/docs/tracking/how-tos/effective-server.md
@@ -109,9 +109,11 @@ Page view tracking must be done manually for server-side implementations. Here a
 
 - Track page views as a single event type by using a constant `event_name`
 - Track different pages as an event property and not as different events for better analysis
+- Plan ahead for handling page views from anonymous users, identified users, and connecting them to merge a user's journey
+  - Get started below with [Identifying Users](/docs/tracking/how-tos/effective-server#identifying-users)
 - Fire page view events only on successful responses to the client
 - Parse headers and the request URL for common web analytics properties such as referrer and UTM parameters
-  - See Mixpanel's [default web event properties](/docs/tracking/reference/default-properties#event-properties) for examples
+  - See above for [parsing user agent](/docs/tracking/how-tos/effective-server#tracking-browser-device-and-os) and [marketing attribution properties](/docs/tracking/how-tos/effective-server#tracking-utms-and-referrer)
 
 ## Identifying Users
 Our server libraries normally require that you specify the distinct_id value for each event. If you _don't_ know the user's identity at the time the event is tracked, then they're an anonymous user. When using our Web or Mobile SDKs, Mixpanel will automatically generate an ID that's local to that user's device. This ID will persist on all events tracked by that user on that device, until you call `identify()` or `reset()`. More on that in our [identity management guide](/docs/tracking/how-tos/identifying-users).

--- a/pages/docs/tracking/how-tos/tracking-utm-tags.md
+++ b/pages/docs/tracking/how-tos/tracking-utm-tags.md
@@ -30,3 +30,5 @@ For iOS, users enter the Apple App Store carrying data about where they came fro
 
 In order to track channel attribution on iOS, you'll need to use a mobile attribution tool. You can see a list of the partners we integrate with on our [tech partners page](https://mixpanel.com/partners/integrations).
 
+## Server-Side Attribution
+Unlike web tracking, server-side implementations generally don't have access to global contexts or variables that can provide attribution data. This means these data such as UTM parameters and referrer information need to be extracted manually from the request. See our [Effective Server-Side Tracking page on tracking attribution](/docs/tracking/how-tos/effective-server#tracking-attribution-from-utms-and-referer) for examples of how this could be done.


### PR DESCRIPTION
Since server SDKs are limited in what they can automatically track, customers will need to implement attribution-related properties manually. We want to help set some expectations and guidance around server-side tracking when it comes to marketing analytics. 