### PR TITLE
Migration Guide Edits

### DIFF
--- a/pages/docs/other-bits/tutorials/migration-guides.md
+++ b/pages/docs/other-bits/tutorials/migration-guides.md
@@ -50,7 +50,7 @@ To backfill data, we recommend:
 - If you have a data warehouse without your current provider's data: Export your data to the data warehouse so you have a record, and then Import API or Reverse ETL
 - If you do not have a data warehouse: Since there is no historical record of data, for this method you will need to export your data from your current provider and move it into Mixpanel - we provide an easy to use helper function for this [here](https://github.com/mixpanel/mixpanel-utils)
 
-It is recommended your Mixpanel champion or owner first set up your [Organization settings](https://docs.mixpanel.com/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-organization) and [Project settings](https://docs.mixpanel.com/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-projects). This will ensure the right access level for your team and enable you to prepare the workspace for ingesting data. This can be done later but doing it up front will allow for you to set key settings for data ingestion (US vs EU servers, project timezone, etc.).
+It is recommended your Mixpanel champion or owner first set up your [Organization settings](/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-organization) and [Project settings](/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-projects). This will ensure the right access level for your team and enable you to prepare the workspace for ingesting data. This can be done later but doing it up front will allow for you to set key settings for data ingestion (US vs EU servers, project timezone, etc.).
 
 It is also recommended you load the data into a test project with a limited subset (for example, a single day or data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
 
@@ -58,8 +58,8 @@ It is also recommended you load the data into a test project with a limited subs
 
 Depending on your current setup, the steps for migrating your live data tracking will differ. Please see the appropriate provider specific guides for more details on how to migrate your existing live data tracking and get started with Mixpanel.
 
-- [Amplitude Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude)
-- [Google Analytics Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics)
+- [Amplitude Migration Guide](/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude)
+- [Google Analytics Migration Guide](/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics)
 
 ### Change management migration of end users
 

--- a/pages/docs/other-bits/tutorials/migration-guides.md
+++ b/pages/docs/other-bits/tutorials/migration-guides.md
@@ -1,0 +1,89 @@
+## Migrating to Mixpanel from Other Analytics Tools
+
+If you’re reading this, congrats on considering making the switch from another analytics provider to Mixpanel 🎊  Our migration guides are intended to outline how a migration works, what to expect, and how to mitigate the risks and switching costs of a migration whilst accelerate time to value.
+
+### What a migration will solve
+
+- Cut-over sending live data to Mixpanel
+- Historical backfill of existing data (subject to what data can be modeled as events)
+- Integrates easily with existing event data collection methods - SDKs, CDPs, DWH, RETL
+
+### What a migration won’t solve
+
+- Existing issues with data trust/quality or data governance → As part of the migration, we recommend a data audit as the first step to only transfer your valuable data and clean up trust/quality issues
+- Reporting, Dashboards, and Saved Entities → As part of the migration, you should review your top used reports and dashboards from other tools and sit down with each team to re-build them in Mixpanel
+
+### What level of effort does the migration take?
+
+A migration primarily consists of 4 phases:
+
+1. Technical migration of data → Data audit, Live data cutover, Historical data import
+2. Change management migration of end users → Champion identification, User interviews, Team by team specific trainings, Ensuring adoption for each team
+3. Data governance and implementation optimization → Improving/Implementing data governance processes, Identifying missing or incorrect data, Optimizing workflows for adding/editing data
+4. Ongoing success planning → Building a product analytics practice
+
+From a technical perspective, the migration process is relatively straightforward. If you have an engineer with access to your data and the ability to write code/transforms to send data to new destinations, this can be done in a single sprint (1-2 weeks).
+
+From an end user perspective, Mixpanel is simpler and easier to learn than other analytics tools but there of course will be a learning curve. The largest hurdle is copying over key saved reports, dashboards, etc. which the team is familiar with in your current tool and teaching them how to rebuild these in Mixpanel. We recommend doing this process in detail for each team, showing them how to recreate key analyses side-by-side in Mixpanel. You can then leverage your team champions to force multiply your adoption efforts.
+
+When going through this migration, there is no better time to audit your own data and reports to only migrate what matters. Most data and reporting is stale after some time anyways, prioritize the data and reports your team uses every day for their Top 10 key questions. These can be easily copied over and Mixpanel also provides Customer Success resources during Onboarding to assist with this.
+
+### Technical migration of data
+
+#### Data audit
+
+We’ve found from experience that <20% of the data in a product analytics tool is used for 80%+ of the queries. This is especially true the longer you have been using a tool - over time teams add more and more tracking for new events and properties, and without strong data governance practices, you will inevitably have some messy data in your current analytics tool(s).
+
+In the spirit of making sense of the mess, it is not recommended that you bring all historical data into Mixpanel. A common practice is to leverage your current providers tooling to understand which reports, events, and properties are queried by your users. No queries in the past 30 days? These events and properties have probably gone stale - there is low value and high effort in brining them to Mixpanel, so cut them from your import and do not migrate the existing tracking.
+
+After you’ve gotten rid of the obvious (the reports, events, and properties no one uses), you can fine tune this approach by doing user interviews with your top users/champions. These users can help you explicitly define the data they need brought along to Mixpanel (mapped to their key questions and KPIs) so you can focus on what matters. Because these users are the ones building reporting others use, capturing their use cases and making them change agents can be highly beneficial to your migration.
+
+This data audit step is optional, but highly recommended - It is a larger upfront investment to avoid higher maintenance costs in the future.
+
+#### Loading historical data
+
+We recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
+
+To backfill data, we recommend:
+
+- If you have a data warehouse: Leverage the [Import API](https://developer.mixpanel.com/reference/import-events) or a Reverse ETL tool to import to Mixpanel
+- If you have a data warehouse without your current provider's data: Export your data to the data warehouse so you have a record, and then Import API or Reverse ETL
+- If you do not have a data warehouse: Since there is no historical record of data, for this method you will need to export your data from your current provider and move it into Mixpanel - we provide an easy to use helper function for this [here](https://github.com/mixpanel/mixpanel-utils)
+
+It is recommended your Mixpanel champion or owner first set up your [Organization settings](https://docs.mixpanel.com/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-organization) and [Project settings](https://docs.mixpanel.com/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-projects). This will ensure the right access level for your team and enable you to prepare the workspace for ingesting data. This can be done later but doing it up front will allow for you to set key settings for data ingestion (US vs EU servers, project timezone, etc.).
+
+It is also recommended you load the data into a test project with a limited subset (for example, a single day or data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
+
+#### Migrating live data tracking
+
+Depending on your current setup, the steps for migrating your live data tracking will differ. Please see the appropriate provider specific guides for more details on how to migrate your existing live data tracking and get started with Mixpanel.
+
+- [Amplitude Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude)
+- [Google Analytics Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics)
+- [Adobe Analytics Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-adobe-analytics)
+
+### Change management migration of end users
+
+Once data is live, we shift our focus to change management and migrating the existing users. We mitigate risk here by:
+
+- Going team by team to assess currently used reports in other analytics providers, as starting with a baseline of key known reports from another tool helps build trust and confidence for new users to Mixpanel
+- Running targeted trainings where we re-build known reports side-by-side in Mixpanel to teach users to fish
+- Building a product with awesome UI/UX that will make up for the up-front costs in simpler, more powerful analysis down the line
+
+Our goal is to focus on each team individually, and we can process multiple in parallel. A team is the perfect unit to focus on as they have shared context and goals, so their needs as far as metrics and analysis will be similar. We can then help each team to the point they can self-serve answers from Mixpanel to answer their questions.
+
+### Data governance and implementation optimization
+
+In many cases, your goal in a migration will be to complete the process as quickly as possible - after all, you may be paying for multiple providers at once. Assessing your data quality and governance is likely to be less of a priority in the short term.
+
+We recommend once your data and users are migrated to utilize your learnings from these processes to assess the current state of your data trust and where you need to address data issues to gain adoption. This might mean needing to implement new datasets or improve existing tracking to increase the number of use cases which can be explored by end users.
+
+### Ongoing success planning
+
+After the migration, we recommend you focus on longer term goals like:
+
+- Improving Data Governance → Creating scaleable processes and strategies for managing data at scale
+- Optimizing Analysis → Helping end users analyze data for more use cases, faster via training and documentation
+- Building a Product Analytics Practice → Cultural change to be a self-serve, data democratized organization
+
+Mixpanel Customer Success will work with you to define your ongoing needs and build a plan specific to the outcomes you need to drive. You can read more about how we do this [here](https://mixpanel.com/blog/establish-a-product-analytics-practice/).

--- a/pages/docs/other-bits/tutorials/migration-guides.md
+++ b/pages/docs/other-bits/tutorials/migration-guides.md
@@ -1,19 +1,17 @@
-## Migrating to Mixpanel from Other Analytics Tools
-
 If you’re reading this, congrats on considering making the switch from another analytics provider to Mixpanel 🎊  Our migration guides are intended to outline how a migration works, what to expect, and how to mitigate the risks and switching costs of a migration whilst accelerate time to value.
 
-### What a migration will solve
+## What a migration will solve
 
 - Cut-over sending live data to Mixpanel
 - Historical backfill of existing data (subject to what data can be modeled as events)
 - Integrates easily with existing event data collection methods - SDKs, CDPs, DWH, RETL
 
-### What a migration won’t solve
+## What a migration won’t solve
 
 - Existing issues with data trust/quality or data governance → As part of the migration, we recommend a data audit as the first step to only transfer your valuable data and clean up trust/quality issues
 - Reporting, Dashboards, and Saved Entities → As part of the migration, you should review your top used reports and dashboards from other tools and sit down with each team to re-build them in Mixpanel
 
-### What level of effort does the migration take?
+## What level of effort does the migration take?
 
 A migration primarily consists of 4 phases:
 
@@ -28,42 +26,42 @@ From an end user perspective, Mixpanel is simpler and easier to learn than other
 
 When going through this migration, there is no better time to audit your own data and reports to only migrate what matters. Most data and reporting is stale after some time anyways, prioritize the data and reports your team uses every day for their Top 10 key questions. These can be easily copied over and Mixpanel also provides Customer Success resources during Onboarding to assist with this.
 
-### Technical migration of data
+## Technical migration of data
 
-#### Data audit
-
-We’ve found from experience that <20% of the data in a product analytics tool is used for 80%+ of the queries. This is especially true the longer you have been using a tool - over time teams add more and more tracking for new events and properties, and without strong data governance practices, you will inevitably have some messy data in your current analytics tool(s).
-
-In the spirit of making sense of the mess, it is not recommended that you bring all historical data into Mixpanel. A common practice is to leverage your current providers tooling to understand which reports, events, and properties are queried by your users. No queries in the past 30 days? These events and properties have probably gone stale - there is low value and high effort in brining them to Mixpanel, so cut them from your import and do not migrate the existing tracking.
-
-After you’ve gotten rid of the obvious (the reports, events, and properties no one uses), you can fine tune this approach by doing user interviews with your top users/champions. These users can help you explicitly define the data they need brought along to Mixpanel (mapped to their key questions and KPIs) so you can focus on what matters. Because these users are the ones building reporting others use, capturing their use cases and making them change agents can be highly beneficial to your migration.
-
-This data audit step is optional, but highly recommended - It is a larger upfront investment to avoid higher maintenance costs in the future.
-
-#### Loading historical data
-
-We recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
-
-To backfill data, we recommend:
-
-- If you have a data warehouse: Leverage the [Import API](https://developer.mixpanel.com/reference/import-events) or a Reverse ETL tool to import to Mixpanel
-- If you have a data warehouse without your current provider's data: Export your data to the data warehouse so you have a record, and then Import API or Reverse ETL
-- If you do not have a data warehouse: Since there is no historical record of data, for this method you will need to export your data from your current provider and move it into Mixpanel - we provide an easy to use helper function for this [here](https://github.com/mixpanel/mixpanel-utils)
-
-It is recommended your Mixpanel champion or owner first set up your [Organization settings](/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-organization) and [Project settings](/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-projects). This will ensure the right access level for your team and enable you to prepare the workspace for ingesting data. This can be done later but doing it up front will allow for you to set key settings for data ingestion (US vs EU servers, project timezone, etc.).
-
-It is also recommended you load the data into a test project with a limited subset (for example, a single day or data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
-
-#### Migrating live data tracking
+### Migrating live data tracking
 
 Depending on your current setup, the steps for migrating your live data tracking will differ. Please see the appropriate provider specific guides for more details on how to migrate your existing live data tracking and get started with Mixpanel.
 
 - [Amplitude Migration Guide](/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude)
 - [Google Analytics Migration Guide](/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics)
 
-### Change management migration of end users
+### Data audit
 
-Once data is live, we shift our focus to change management and migrating the existing users. We mitigate risk here by:
+We’ve found from experience that <20% of the data in a product analytics tool is used for 80%+ of the queries. This is especially true the longer you have been using a tool - over time teams add more and more tracking for new events and properties, and without strong data governance practices, you will inevitably have some messy data in your current analytics tool(s).
+
+In the spirit of making sense of the mess, we don't recommended that you bring all historical data into Mixpanel. A common practice is to leverage your current providers tooling to understand which reports, events, and properties are queried by your users. No queries in the past 30 days? These events and properties have probably gone stale - there is low value and high effort in brining them to Mixpanel, so cut them from your import and do not migrate the existing tracking.
+
+After you’ve gotten rid of the obvious (the reports, events, and properties no one uses), you can fine tune this approach by doing user interviews with your top users/champions. These users can help you explicitly define the data they need brought along to Mixpanel (mapped to their key questions and KPIs) so you can focus on what matters. Because these users are the ones building reporting others use, capturing their use cases and making them change agents can be highly beneficial to your migration.
+
+This data audit step is optional, but highly recommended - It is a larger upfront investment to avoid higher maintenance costs in the future.
+
+### Loading historical data
+
+To backfill data, we recommend the following approaches:
+
+- If you have a data warehouse: Leverage the [Import API](https://developer.mixpanel.com/reference/import-events) or a Reverse ETL tool to import to Mixpanel
+- If you have a data warehouse without your current provider's data: Export your data to the data warehouse so you have a record, and then Import API or Reverse ETL
+- If you do not have a data warehouse: Since there is no historical record of data, for this method you will need to export your data from your current provider and move it into Mixpanel - we provide an easy to use helper function for this [here](https://github.com/mixpanel/mixpanel-utils)
+
+To performa successful historical data load, we recommend:
+
+- Have our Mixpanel champion or owner first set up your [Organization settings](/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-organization) and [Project settings](/docs/other-bits/tutorials/setting-up-mixpanel#mixpanel-projects). This will ensure the right access level for your team and enable you to prepare the workspace for ingesting data. This can be done later but doing it up front will allow for you to set key settings for data ingestion (US vs EU servers, project timezone, etc.).
+- Load a limited subset of the data into a test project (for example, a single day or data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
+- Load a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed, without sending a bunch of data which is stale and unlikely to be used.
+
+## Change management migration of end users
+
+Once data is live, we shift our focus to change management and migrating the existing users. You can mitigate risk here by:
 
 - Going team by team to assess currently used reports in other analytics providers, as starting with a baseline of key known reports from another tool helps build trust and confidence for new users to Mixpanel
 - Running targeted trainings where we re-build known reports side-by-side in Mixpanel to teach users to fish
@@ -71,13 +69,13 @@ Once data is live, we shift our focus to change management and migrating the exi
 
 Our goal is to focus on each team individually, and we can process multiple in parallel. A team is the perfect unit to focus on as they have shared context and goals, so their needs as far as metrics and analysis will be similar. We can then help each team to the point they can self-serve answers from Mixpanel to answer their questions.
 
-### Data governance and implementation optimization
+## Data governance and implementation optimization
 
 In many cases, your goal in a migration will be to complete the process as quickly as possible - after all, you may be paying for multiple providers at once. Assessing your data quality and governance is likely to be less of a priority in the short term.
 
 We recommend once your data and users are migrated to utilize your learnings from these processes to assess the current state of your data trust and where you need to address data issues to gain adoption. This might mean needing to implement new datasets or improve existing tracking to increase the number of use cases which can be explored by end users. You can read more around our recommended approach and questions to ask yourself [here](https://mixpanel.com/blog/5-questions-for-planning-your-data-architecture/).
 
-### Ongoing success planning
+## Ongoing success planning
 
 After the migration, we recommend you focus on longer term goals like:
 
@@ -85,4 +83,4 @@ After the migration, we recommend you focus on longer term goals like:
 - Optimizing Analysis → Helping end users analyze data for more use cases, faster via training and documentation
 - Building a Product Analytics Practice → Cultural change to be a self-serve, data democratized organization
 
-Mixpanel Customer Success will work with you to define your ongoing needs and build a plan specific to the outcomes you need to drive. You can read more about how we do this [here](https://mixpanel.com/blog/establish-a-product-analytics-practice/).
+Mixpanel Customer Success & Support will work with you to define your ongoing needs and build a plan specific to the outcomes you need to drive. You can read more about how we do this [here](https://mixpanel.com/blog/establish-a-product-analytics-practice/).

--- a/pages/docs/other-bits/tutorials/migration-guides.md
+++ b/pages/docs/other-bits/tutorials/migration-guides.md
@@ -60,7 +60,6 @@ Depending on your current setup, the steps for migrating your live data tracking
 
 - [Amplitude Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude)
 - [Google Analytics Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics)
-- [Adobe Analytics Migration Guide](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-adobe-analytics)
 
 ### Change management migration of end users
 

--- a/pages/docs/other-bits/tutorials/migration-guides.md
+++ b/pages/docs/other-bits/tutorials/migration-guides.md
@@ -76,7 +76,7 @@ Our goal is to focus on each team individually, and we can process multiple in p
 
 In many cases, your goal in a migration will be to complete the process as quickly as possible - after all, you may be paying for multiple providers at once. Assessing your data quality and governance is likely to be less of a priority in the short term.
 
-We recommend once your data and users are migrated to utilize your learnings from these processes to assess the current state of your data trust and where you need to address data issues to gain adoption. This might mean needing to implement new datasets or improve existing tracking to increase the number of use cases which can be explored by end users.
+We recommend once your data and users are migrated to utilize your learnings from these processes to assess the current state of your data trust and where you need to address data issues to gain adoption. This might mean needing to implement new datasets or improve existing tracking to increase the number of use cases which can be explored by end users. You can read more around our recommended approach and questions to ask yourself [here](https://mixpanel.com/blog/5-questions-for-planning-your-data-architecture/).
 
 ### Ongoing success planning
 

--- a/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
+++ b/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
@@ -43,10 +43,10 @@ Mixpanel accepts event data from a variety of different sources. Choose your imp
 
 We support the following data collection mechanisms:
 
-- Client-side SDKs & Server-side SDKs: Simply replace Amplitude code calls to track events with Mixpanel calls instead
-- Customer Data Platforms (CDPs) like [Segment](https://segment.com/): Go into your CDP settings to add Mixpanel as a destination, and point your data stream to Mixpanel
-- Import API: Point your event ingestion pipeline to [Mixpanel’s robust API](https://developer.mixpanel.com/reference/import-events) for data ingestion
-- [Reverse ETL](https://mixpanel.com/blog/what-is-reverse-etl-product-data/) (RETL) tools like [Census](https://getcensus.com): Go into your RETL settings to add Mixpanel as a destination, and point your syncs to Mixpanel
+- [Client-side SDKs & Server-side SDKs](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#client-side-sdks--server-side-sdks): Simply replace Amplitude code calls to track events with Mixpanel calls instead
+- [Customer Data Platforms (CDPs)](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#customer-data-platforms-cdps) like [Segment](https://segment.com/): Go into your CDP settings to add Mixpanel as a destination, and point your data stream to Mixpanel
+- [Import API](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#import-api): Point your event ingestion pipeline to [Mixpanel’s robust API](https://developer.mixpanel.com/reference/import-events) for data ingestion
+- [Reverse ETL](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#reverse-etl-retl) (RETL) tools like [Census](https://getcensus.com): Go into your RETL settings to add Mixpanel as a destination, and point your syncs to Mixpanel
 
 ### Client-side SDKs & Server-side SDKs
     
@@ -78,6 +78,7 @@ mixpanel.init('new token')
 ```
 
 [Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit)
+
 [Initialization (init) options](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_config)
 
 #### Events
@@ -146,7 +147,7 @@ mixpanel.set_group('orgId', 15)
 
 [Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_group)
 
-###Customer Data Platforms (CDPs)
+### Customer Data Platforms (CDPs)
     
 Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination:
 
@@ -164,15 +165,15 @@ We provide Mixpanel as a destination and setup guides for all of the most popula
 - [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
 - [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
 
-Note depending on your CDP provider, they may also be able to help with migrating historical data as well. Features like [Segment Replay](https://segment.com/docs/guides/what-is-replay/) enable you to quickly backfill historical data during your migration.
+Note depending on your CDP provider, they may also be able to help with migrating historical data as well. Features like [Segment Replay](https://segment.com/docs/guides/what-is-replay/) enable you to quickly backfill historical data during your migration versus needing to do this work with your developer resources.
     
-###Import API
+### Import API
     
 If you currently send data to Amplitude directly to their API, you can simply swap out the Amplitude API with the Mixpanel API.
 
-####Sending Events
+#### Sending Events
 
-Amplitude’s `/track` API Endpoint is [https://api2.amplitude.com/2/httpapi](https://api2.amplitude.com/2/httpapi)` (documented [here](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/)). A sample request from your server for this API would look like:
+Amplitude’s `/track` API Endpoint is `https://api2.amplitude.com/2/httpapi` (documented [here](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/)). A sample request from your server for this API would look like:
 
 ```bash
 curl -X POST https://api2.amplitude.com/2/httpapi \
@@ -188,7 +189,7 @@ curl -X POST https://api2.amplitude.com/2/httpapi \
     }'
 ```
 
-Mixpanel’s `/track` API endpoint is [https://api.mixpanel.com/import](https://api.mixpanel.com/import) (documented [here](https://developer.mixpanel.com/reference/import-events)). A sample request from your server for this API would look like:
+Mixpanel’s `/track` API endpoint is `https://api.mixpanel.com/import` (documented [here](https://developer.mixpanel.com/reference/import-events)). A sample request from your server for this API would look like:
 
 ```bash
 curl --request POST \
@@ -212,9 +213,9 @@ curl --request POST \
 The big difference between the APIs are:
 
 - **Authentication:** Amplitude authenticates in the request payload, whereas Mixpanel uses your project token in the request URL alongside basic auth. Mixpanel authentication can be done via a service account as described [here](https://developer.mixpanel.com/reference/ingestion-api-authentication). Be sure to move the authentication outside the payload.
-- **Event JSON Structure:** Amplitude and Mixpanel have slightly different structures (explained [here]()). You will want to remap the Amplitude event format to the expected Mixpanel JSON payload as described [here](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da).
+- **Event JSON Structure:** Amplitude and Mixpanel have slightly different structures (explained [here](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#differences-in-the-data-models)). You will want to remap the Amplitude event format to the expected Mixpanel JSON payload as described [here](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da).
 
-###Reverse ETL (RETL)
+### Reverse ETL (RETL)
 
 If you already send data to Amplitude with your data warehouse as the source of truth using reverse ETL, sending data to Mixpanel requires adding a new destination and syncing the same models you have been syncing to Amplitude. This option is like a hybrid between the CDP and Import API options above - you can use the reverse ETL tool to set Mixpanel up simply as a destination and then the tool will handle all of the remapping at the API level for you.
 
@@ -222,10 +223,14 @@ Simply go to your RETL settings and add Mixpanel as a connection:
 
 ![Census Connection](https://user-images.githubusercontent.com/129823695/234812805-ded7dcef-9d47-4375-b52e-a229e4832477.png)
 
-
 We provide Mixpanel as a destination and setup guides for all of the most popular RETL tools:
 
 - [Census](https://docs.getcensus.com/destinations/mixpanel)
 - [Hightouch](https://hightouch.com/docs/destinations/mixpanel)
 - [Segment](https://segment.com/docs/connections/reverse-etl/)
-    
+
+### Not sure where to start or need help?
+
+If you're unsure how you currently track data, or might want to consider tracking data differently as you migrate to Mixpanel, we recommend starting [here](https://mixpanel.com/blog/guide-to-choosing-your-data-architecture/).
+
+Mixpanel Customer Success and Support have been helping thousands of customers migrate from other tools to Mixpanel over the past decade. If you need help, just [reach out here](https://mixpanel.com/get-support) and we'll be ready to assist with advice specific to your situation.

--- a/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
+++ b/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
@@ -1,226 +1,8 @@
-# Migrating to Mixpanel from Amplitude
+## Migrating to Mixpanel from Amplitude
 
-If you’re reading this, congrats on considering making the switch from Amplitude to Mixpanel 🎊  This guide is intended to outline how the migration works, what to expect, and how to mitigate the risks and switching costs of a migration whilst accelerate time to value.
+If you haven't already, we recommend starting with our [Migration Guides Overview](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Amplitude.
 
-## What a migration will solve ✅
-
-- Cut-over sending live data to Mixpanel and stop sending to Amplitude
-- Historical backfill of existing data
-- Integrates easily with existing event data collection methods - SDKs, CDPs, DWH, RETL
-- Migrates all existing/new data in entirety - full access to all events and properties you had in Amplitude
-
-## What a migration won’t solve ⛔
-
-- Existing issues with data trust/quality or data governance → As part of the migration, we recommend a [data audit](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da) as the first step to only transfer your valuable data and clean up trust/quality issues
-- Reporting, Dashboards, and Saved Entities → As part of the migration, we can review your top used reports and dashboards then [sit down with each team](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da) to re-build them in Mixpanel
-
-## What level of effort does the migration take? ⚖️
-
-A migration primarily consists of 3 phases:
-
-1. Technical migration of data → Data audit, Live data cutover, Historical data import
-2. Change management migration of end users → Champion identification, User interviews, Team by team specific trainings, Ensuring adoption for each team
-3. Ongoing success planning → Improving data governance, Optimizing analysis, Building a product analytics practice
-
-From a technical perspective, the migration process is relatively straightforward. If you have an engineer with access to your data and the ability to write code/transforms to send data to new destinations, this can be done in a single sprint (1-2 weeks).
-
-From an end user perspective, Mixpanel is simpler and easier to learn than Amplitude but there of course will be a learning curve. The largest hurdle is copying over key saved reports, dashboards, etc. which the team is familiar with in Amplitude and teaching them how to rebuild these in Mixpanel. We recommend doing this process in detail for each team, showing them how to recreate key analyses side-by-side in Mixpanel. You can then leverage your team champions to force multiply your adoption efforts.
-
-When going through this migration, there is no better time to audit your own data and reports to only migrate what matters. Most data and reporting is stale after some time anyways, prioritize the data and reports your team uses every day for their Top 10 key questions. These can be easily copied over and Mixpanel also provides Customer Success resources during Onboarding to assist with this.
-
-## Getting started: Identify your implementation method 🚦
-
-Mixpanel accepts event data from a variety of different sources. Choose your implementation method first and then you can follow the below steps for sending data to Mixpanel.
-
-We support the following data collection mechanisms:
-
-- Client-side SDKs & Server-side SDKs: Simply replace Amplitude code calls to track events with Mixpanel calls instead
-    
-    Fortunately, Mixpanel and Amplitude’s client side SDKs have *very similar* developer facing APIs. This makes it fairly easy to “find and replace” embedded Amplitude calls and swap them for Mixpanel calls.
-    
-    This section will detail the Javascript SDKs (for the sake of brevity), although both analytics platforms have fairly uniform tracking APIs for other SDKs (mobile, server-side). 
-    
-    Amplitude JS Docs: [https://amplitude.github.io/Amplitude-JavaScript/](https://amplitude.github.io/Amplitude-JavaScript/)
-    
-    Mixpanel JS Docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference](https://developer.mixpanel.com/docs/javascript-full-api-reference)
-    
-    ## Installing the Mixpanel SDK:
-    
-    [https://developer.mixpanel.com/docs/javascript-quickstart#1-initialize-the-library](https://developer.mixpanel.com/docs/javascript-quickstart#1-initialize-the-library)
-    
-    # Migrating Amplitude ⇒ Mixpanel
-    
-    ### Initialization
-    
-    Amplitude’s `init()` method:
-    
-    ```jsx
-    var amplitudeClient = new AmplitudeClient();
-    amplitudeClient.init('API_KEY')
-    ```
-    
-    Mixpanel’s `init()` method:
-    
-    ```jsx
-    mixpanel.init('new token')
-    ```
-    
-    docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit)
-    
-    init options: [https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_config](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_config)
-    
-    ### Events
-    
-    Amplitude’s `logEvent()` method:
-    
-    ```jsx
-    amplitudeClient.logEvent('Clicked Button', {'finished_flow': false });
-    ```
-    
-    Mixpanel’s `track()` method:
-    
-    ```jsx
-    mixpanel.track('Clicked Button', {'finished_flow': false })
-    ```
-    
-    docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack)
-    
-    ### Identity Management
-    
-    Amplitude’s `setUserId()` method:
-    
-    ```jsx
-    amplitudeClient.setUserId('joe@gmail.com');
-    ```
-    
-    Mixpanel’s `identify()` method:
-    
-    ```jsx
-    mixpanel.identify('joe@gmail.com')
-    ```
-    
-    docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelidentify](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelidentify)
-    
-    ### User Properties
-    
-    Amplitude’s `setUserProperties()` method:
-    
-    ```jsx
-    amplitudeClient.setUserProperties({'gender': 'female', 'sign_up_complete': true})
-    ```
-    
-    Mixpanel’s `people.set()` method:
-    
-    ```jsx
-    mixpanel.people.set({'gender': 'female', 'sign_up_complete': true})
-    ```
-    
-    docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelpeople](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelpeople)
-    
-    notes: `identify()` should be called at some point in the user’s session to propagate people methods
-    
-    ### Group Analytics
-    
-    Amplitude’s `setGroup()` method:
-    
-    ```jsx
-    amplitudeClient.setGroup('orgId', 15); 
-    ```
-    
-    Mixpanel’s `set_group()` method:
-    
-    ```jsx
-    mixpanel.set_group('orgId', 15)
-    ```
-    
-    docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_group](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_group)
-    
-- Customer Data Platforms (CDPs) like [Segment](https://segment.com/): Go into your CDP settings to add Mixpanel as a destination, and point your data stream to Mixpanel
-    
-    Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination:
-    
-    ![Segment Connection](https://user-images.githubusercontent.com/129823695/234812593-dffee962-bb34-49b8-9686-96bc0f0565d8.png)
-
-    
-    Once you set up the connection to Mixpanel, you can proceed with configuring key settings like:
-    
-    - which events and properties to send → only send what matters
-    - edit any mappings/editing/filtering that has to be done on the data → ensure high data quality and governance
-    - connection settings, or CDP specific settings for data syncs → control over how data is sent
-    
-    We provide Mixpanel as a destination and setup guides for all of the most popular CDPs:
-    
-    - [Segment](https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/)
-    - [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
-    - [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
-    
-- [Import API](https://developer.mixpanel.com/reference/import-events): Point your event ingestion pipeline to [Mixpanel’s robust API](https://developer.mixpanel.com/reference/import-events) for data ingestion
-    
-    If you currently send data to Amplitude directly to their API, you can simply swap out the Amplitude API with the Mixpanel API.
-    
-    ### Sending Events
-    
-    Amplitude’s `/track` API Endpoint is `[https://api2.amplitude.com/2/httpapi](https://api2.amplitude.com/2/httpapi)` (documented [here](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/)). A sample request from your server for this API would look like:
-    
-    ```bash
-    curl -X POST https://api2.amplitude.com/2/httpapi \
-        -H 'Content-Type: application/json' \
-        -H 'Accept: */*' \
-        --data '{
-            "api_key": "YOUR_API_KEY",
-            "events": [{
-            "user_id": "203201202",
-            "device_id": "C8F9E604-F01A-4BD9-95C6-8E5357DF265D",
-            "event_type": "watch_tutorial"
-            }]
-            }'
-    ```
-    
-    Mixpanel’s `/track` API endpoint is [`https://api.mixpanel.com/import`](https://api.mixpanel.com/import) (documented [here](https://developer.mixpanel.com/reference/import-events)). A sample request from your server for this API would look like:
-    
-    ```bash
-    curl --request POST \
-         --url 'https://api.mixpanel.com/import?strict=1&project_id=%3CYOUR_PROJECT_ID%3E' \
-         --header 'Content-Encoding: gzip' \
-         --header 'Content-Type: application/json' \
-         --header 'accept: application/json' \
-         --header 'authorization: Basic cnlhbjpyeWFu' \
-         --data '
-    [
-      {
-        "event": "string",
-        "properties": {
-          "time": 0,
-          "distinct_id": "string",
-          "$insert_id": "string"
-        }
-      }
-    ]
-    '
-    ```
-    
-    The big difference between the APIs are:
-    
-    - **Authentication:** Amplitude authenticates in the request payload, whereas Mixpanel uses your project token in the request URL alongside basic auth. Mixpanel authentication can be done via a service account as described [here](https://developer.mixpanel.com/reference/ingestion-api-authentication). Be sure to move the authentication outside the payload.
-    - **Event JSON Structure:** Amplitude and Mixpanel have slightly different structures (explained further below). You will want to remap the Amplitude event format to the expected Mixpanel JSON payload as described [here](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da).
-    
-- [Reverse ETL](https://mixpanel.com/blog/what-is-reverse-etl-product-data/) (RETL) tools like [Census](https://getcensus.com): Go into your RETL settings to add Mixpanel as a destination, and point your syncs to Mixpanel
-    
-    If you already send data to Amplitude with your data warehouse as the source of truth using reverse ETL, sending data to Mixpanel requires adding a new destination and syncing the same models you have been syncing to Amplitude. This option is like a hybrid between the CDP and Import API options above - you can use the reverse ETL tool to set Mixpanel up simply as a destination and then the tool will handle all of the remapping at the API level for you.
-    
-    Simply go to your RETL settings and add Mixpanel as a connection:
-    
-    ![Census Connection](https://user-images.githubusercontent.com/129823695/234812805-ded7dcef-9d47-4375-b52e-a229e4832477.png)
-
-    
-    We provide Mixpanel as a destination and setup guides for all of the most popular RETL tools:
-    
-    - [Census](https://docs.getcensus.com/destinations/mixpanel)
-    - [Hightouch](https://hightouch.com/docs/destinations/mixpanel)
-    - [Segment](https://segment.com/docs/connections/reverse-etl/)
-    
-
-## Differences in the data models ☯️
+### Differences in the data models
 
 Both Mixpanel and Amplitude are product analytics tools which collect event-based behavioral data about your users. [Events](https://developer.mixpanel.com/reference/import-events) are commonly expressed as JSON which represent the name of the user action, the ID of the user, the time at which the action took place, and all associated metadata. Events are immutable, and represent data at the time of which an action takes place.
 
@@ -255,46 +37,195 @@ We also support additional data for extending your use cases with Mixpanel:
 - [Group profiles](https://developer.mixpanel.com/reference/group-set-property): Used with our Group Analytics product add-on to allow you to pivot quickly between users and other entities in your analysis. A common use case is for a B2B company to pivot between analyzing users and analyzing accounts.
 - [Lookup tables](https://developer.mixpanel.com/reference/lookup-tables): For event data which was already sent, you can use these to extend the data already sent into Mixpanel. A common use case is taking an identifier like a transaction ID, item ID, etc. and using lookup tables to enrich the data with additional information like the amount, category, etc. from your data warehouse.
 
-## Data audit: Cleaning up the mess 🧹
+### Identifying your implementation method
 
-We’ve found from experience that <20% of the data in a product analytics tool is used for 80%+ of the queries. This is especially true the longer you have been using a tool - over time teams add more and more tracking for new events and properties, and without strong data governance practices, you will inevitably have some messy data in Amplitude.
+Mixpanel accepts event data from a variety of different sources. Choose your implementation method first and then you can follow the below steps for sending data to Mixpanel.
 
-In the spirit of making sense of the mess, it is not recommended that you bring all historical data in from Amplitude. A common practice is to leverage Amplitude’s [Data](http://data.amplitude.com) Product to first understand which events and properties are queried by your users. No queries in the past 30 days? These events and properties have probably gone stale - there is low value and high effort in brining them to Mixpanel, so cut them from your import and do not migrate the existing tracking.
+We support the following data collection mechanisms:
 
-After you’ve gotten rid of the obvious (the events and properties no one uses), you can fine tune this approach by doing user interviews with your top users/champions. These users can help you explicitly define the data they need brought along to Mixpanel (mapped to their key questions and KPIs) so you can focus on what matters. Because these users are the ones building reporting others use, capturing their use cases and making them change agents can be highly beneficial to your migration.
+- Client-side SDKs & Server-side SDKs: Simply replace Amplitude code calls to track events with Mixpanel calls instead
+- Customer Data Platforms (CDPs) like [Segment](https://segment.com/): Go into your CDP settings to add Mixpanel as a destination, and point your data stream to Mixpanel
+- Import API: Point your event ingestion pipeline to [Mixpanel’s robust API](https://developer.mixpanel.com/reference/import-events) for data ingestion
+- [Reverse ETL](https://mixpanel.com/blog/what-is-reverse-etl-product-data/) (RETL) tools like [Census](https://getcensus.com): Go into your RETL settings to add Mixpanel as a destination, and point your syncs to Mixpanel
 
-This data audit step is optional, but highly recommended - It is a larger upfront investment to avoid higher maintenance costs in the future.
+### Client-side SDKs & Server-side SDKs
+    
+Fortunately, Mixpanel and Amplitude’s client side SDKs have *very similar* developer facing APIs. This makes it fairly easy to “find and replace” embedded Amplitude calls and swap them for Mixpanel calls.
 
-## Loading historical data 📊
+This section will detail the Javascript SDKs (for the sake of brevity), although both analytics platforms have fairly uniform tracking APIs for other SDKs (mobile, server-side).
 
-We recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
+Amplitude JS Docs: [https://amplitude.github.io/Amplitude-JavaScript/](https://amplitude.github.io/Amplitude-JavaScript/)
 
-To backfill data, we recommend:
+Mixpanel JS Docs: [https://developer.mixpanel.com/docs/javascript-full-api-reference](https://developer.mixpanel.com/docs/javascript-full-api-reference)
 
-- If you have a data warehouse with Amplitude data: Leverage the Import API or a Reverse ETL tool to import to Mixpanel
-- If you have a data warehouse without Amplitude data: Export your data to the data warehouse so you have a record, and then Import API or Reverse ETL
-- If you do not have a data warehouse: Since there is no historical record of data, for this method you will need to export your data from Amplitude and move it into Mixpanel - we provide an easy to use helper function for this [here](https://github.com/mixpanel/mixpanel-utils#import-from-amplitude)
+#### Installing the Mixpanel SDK
 
-It is also recommended you load the data into a test project with a limited subset (for ex, a single day or data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
+Before getting started, initialize the Mixpanel SDK according to the directions [here](https://developer.mixpanel.com/docs/javascript-quickstart#1-initialize-the-library)
 
-## Change management: Moving the users 👥
+#### Initialization
 
-It is recommended your Mixpanel champion or owner first set up your [Organization settings](https://help.mixpanel.com/hc/en-us/articles/360021085271-Organization-Settings) and [Project settings](https://help.mixpanel.com/hc/en-us/articles/115004490503-Project-Settings). This will ensure the right access level for your team and enable you to prepare the workspace for ingestion. This can be done later but doing it up front will allow for you to set key settings for data ingestion (US vs EU servers, project timezone, etc.).
+Amplitude’s `init()` method:
 
-Once data is live, we shift our focus to change management and migrating the existing users. We mitigate risk here by:
+```jsx
+var amplitudeClient = new AmplitudeClient();
+amplitudeClient.init('API_KEY')
+```
 
-- Going team by team to assess current Amplitude reports, and bringing over only what really matters
-- Running targeted trainings where we re-build Amplitude reports side-by-side in Mixpanel to teach users to fish
-- Building a product with awesome UI/UX that will make up for the up-front costs in simpler, more powerful analysis down the line
+Mixpanel’s `init()` method:
 
-Our goal is to focus on each team individually, and we can process multiple in parallel. A team is the perfect unit to focus on as they have shared context and goals, so their needs as far as metrics and analysis will be similar. We can then help each team to the point they can self-serve answers from Mixpanel to answer their questions.
+```jsx
+mixpanel.init('new token')
+```
 
-## Ongoing Success 🎡
+[Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelinit)
+[Initialization (init) options](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_config)
 
-After the migration, we often focus on longer term goals like:
+#### Events
 
-- Improving Data Governance → Creating scaleable processes and strategies for managing data at scale
-- Optimizing Analysis → Helping end users analyze data for more use cases, faster
-- Building a Product Analytics Practice → Cultural change to be a self-serve, data democratized organization
+Amplitude’s `logEvent()` method:
 
-Mixpanel Customer Success will work with you to define your ongoing needs and build a plan specific to the outcomes you need to drive. You can read more about how we do this [here](https://mixpanel.com/blog/establish-a-product-analytics-practice/).
+```jsx
+amplitudeClient.logEvent('Clicked Button', {'finished_flow': false });
+```
+
+Mixpanel’s `track()` method:
+
+```jsx
+mixpanel.track('Clicked Button', {'finished_flow': false })
+```
+
+[Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpaneltrack)
+
+#### Identity Management
+
+Amplitude’s `setUserId()` method:
+
+```jsx
+amplitudeClient.setUserId('joe@gmail.com');
+```
+
+Mixpanel’s `identify()` method:
+
+```jsx
+mixpanel.identify('joe@gmail.com')
+```
+
+[Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelidentify)
+
+#### User Properties
+
+Amplitude’s `setUserProperties()` method:
+
+```jsx
+amplitudeClient.setUserProperties({'gender': 'female', 'sign_up_complete': true})
+```
+
+Mixpanel’s `people.set()` method:
+
+```jsx
+mixpanel.people.set({'gender': 'female', 'sign_up_complete': true})
+```
+
+Note: `identify()` should be called at some point in each user’s session to propagate people methods
+
+[Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelpeople)
+
+#### Group Analytics
+
+Amplitude’s `setGroup()` method:
+
+```jsx
+amplitudeClient.setGroup('orgId', 15); 
+```
+
+Mixpanel’s `set_group()` method:
+
+```jsx
+mixpanel.set_group('orgId', 15)
+```
+
+[Docs Reference](https://developer.mixpanel.com/docs/javascript-full-api-reference#mixpanelset_group)
+
+###Customer Data Platforms (CDPs)
+    
+Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination:
+
+![Segment Connection](https://user-images.githubusercontent.com/129823695/234812593-dffee962-bb34-49b8-9686-96bc0f0565d8.png)
+
+Once you set up the connection to Mixpanel, you can proceed with configuring key settings like:
+
+- Which events and properties to send → only send what matters
+- Edit any mappings/editing/filtering that has to be done on the data → ensure high data quality and governance
+- Connection settings, or CDP specific settings for data syncs → control over how data is sent
+
+We provide Mixpanel as a destination and setup guides for all of the most popular CDPs:
+
+- [Segment](https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/)
+- [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
+- [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
+
+Note depending on your CDP provider, they may also be able to help with migrating historical data as well. Features like [Segment Replay](https://segment.com/docs/guides/what-is-replay/) enable you to quickly backfill historical data during your migration.
+    
+###Import API
+    
+If you currently send data to Amplitude directly to their API, you can simply swap out the Amplitude API with the Mixpanel API.
+
+####Sending Events
+
+Amplitude’s `/track` API Endpoint is [https://api2.amplitude.com/2/httpapi](https://api2.amplitude.com/2/httpapi)` (documented [here](https://www.docs.developers.amplitude.com/analytics/apis/http-v2-api/)). A sample request from your server for this API would look like:
+
+```bash
+curl -X POST https://api2.amplitude.com/2/httpapi \
+-H 'Content-Type: application/json' \
+-H 'Accept: */*' \
+--data '{
+    "api_key": "YOUR_API_KEY",
+    "events": [{
+    "user_id": "203201202",
+    "device_id": "C8F9E604-F01A-4BD9-95C6-8E5357DF265D",
+    "event_type": "watch_tutorial"
+    }]
+    }'
+```
+
+Mixpanel’s `/track` API endpoint is [https://api.mixpanel.com/import](https://api.mixpanel.com/import) (documented [here](https://developer.mixpanel.com/reference/import-events)). A sample request from your server for this API would look like:
+
+```bash
+curl --request POST \
+ --url 'https://api.mixpanel.com/import?strict=1&project_id=%3CYOUR_PROJECT_ID%3E' \
+ --header 'Content-Encoding: gzip' \
+ --header 'Content-Type: application/json' \
+ --header 'accept: application/json' \
+ --header 'authorization: Basic cnlhbjpyeWFu' \
+ --data '[
+    {
+        "event": "string",
+        "properties": {
+            "time": 0,
+            "distinct_id": "string",
+            "$insert_id": "string"
+         }
+    }
+]'
+```
+
+The big difference between the APIs are:
+
+- **Authentication:** Amplitude authenticates in the request payload, whereas Mixpanel uses your project token in the request URL alongside basic auth. Mixpanel authentication can be done via a service account as described [here](https://developer.mixpanel.com/reference/ingestion-api-authentication). Be sure to move the authentication outside the payload.
+- **Event JSON Structure:** Amplitude and Mixpanel have slightly different structures (explained [here]()). You will want to remap the Amplitude event format to the expected Mixpanel JSON payload as described [here](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da).
+
+###Reverse ETL (RETL)
+
+If you already send data to Amplitude with your data warehouse as the source of truth using reverse ETL, sending data to Mixpanel requires adding a new destination and syncing the same models you have been syncing to Amplitude. This option is like a hybrid between the CDP and Import API options above - you can use the reverse ETL tool to set Mixpanel up simply as a destination and then the tool will handle all of the remapping at the API level for you.
+
+Simply go to your RETL settings and add Mixpanel as a connection:
+
+![Census Connection](https://user-images.githubusercontent.com/129823695/234812805-ded7dcef-9d47-4375-b52e-a229e4832477.png)
+
+
+We provide Mixpanel as a destination and setup guides for all of the most popular RETL tools:
+
+- [Census](https://docs.getcensus.com/destinations/mixpanel)
+- [Hightouch](https://hightouch.com/docs/destinations/mixpanel)
+- [Segment](https://segment.com/docs/connections/reverse-etl/)
+    

--- a/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
+++ b/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
@@ -1,8 +1,8 @@
-## Migrating to Mixpanel from Amplitude
+# Migrating to Mixpanel from Amplitude
 
 If you haven't already, we recommend starting with our [Migration Guides Overview](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Amplitude.
 
-### Differences in the data models
+## Differences in the data models
 
 Both Mixpanel and Amplitude are product analytics tools which collect event-based behavioral data about your users. [Events](https://developer.mixpanel.com/reference/import-events) are commonly expressed as JSON which represent the name of the user action, the ID of the user, the time at which the action took place, and all associated metadata. Events are immutable, and represent data at the time of which an action takes place.
 
@@ -37,7 +37,7 @@ We also support additional data for extending your use cases with Mixpanel:
 - [Group profiles](https://developer.mixpanel.com/reference/group-set-property): Used with our Group Analytics product add-on to allow you to pivot quickly between users and other entities in your analysis. A common use case is for a B2B company to pivot between analyzing users and analyzing accounts.
 - [Lookup tables](https://developer.mixpanel.com/reference/lookup-tables): For event data which was already sent, you can use these to extend the data already sent into Mixpanel. A common use case is taking an identifier like a transaction ID, item ID, etc. and using lookup tables to enrich the data with additional information like the amount, category, etc. from your data warehouse.
 
-### Identifying your implementation method
+## Identifying your implementation method
 
 Mixpanel accepts event data from a variety of different sources. Choose your implementation method first and then you can follow the below steps for sending data to Mixpanel.
 
@@ -229,7 +229,7 @@ We provide Mixpanel as a destination and setup guides for all of the most popula
 - [Hightouch](https://hightouch.com/docs/destinations/mixpanel)
 - [Segment](https://segment.com/docs/connections/reverse-etl/)
 
-### Not sure where to start or need help?
+## Not sure where to start or need help?
 
 If you're unsure how you currently track data, or might want to consider tracking data differently as you migrate to Mixpanel, we recommend starting [here](https://mixpanel.com/blog/guide-to-choosing-your-data-architecture/).
 

--- a/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
+++ b/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude.md
@@ -1,6 +1,4 @@
-# Migrating to Mixpanel from Amplitude
-
-If you haven't already, we recommend starting with our [Migration Guides Overview](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Amplitude.
+If you haven't already, we recommend starting with our [Migration Guides Overview](/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Amplitude.
 
 ## Differences in the data models
 
@@ -43,10 +41,10 @@ Mixpanel accepts event data from a variety of different sources. Choose your imp
 
 We support the following data collection mechanisms:
 
-- [Client-side SDKs & Server-side SDKs](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#client-side-sdks--server-side-sdks): Simply replace Amplitude code calls to track events with Mixpanel calls instead
-- [Customer Data Platforms (CDPs)](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#customer-data-platforms-cdps) like [Segment](https://segment.com/): Go into your CDP settings to add Mixpanel as a destination, and point your data stream to Mixpanel
-- [Import API](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#import-api): Point your event ingestion pipeline to [Mixpanel’s robust API](https://developer.mixpanel.com/reference/import-events) for data ingestion
-- [Reverse ETL](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#reverse-etl-retl) (RETL) tools like [Census](https://getcensus.com): Go into your RETL settings to add Mixpanel as a destination, and point your syncs to Mixpanel
+- [Client-side SDKs & Server-side SDKs](#client-side-sdks--server-side-sdks): Simply replace Amplitude code calls to track events with Mixpanel calls instead
+- [Customer Data Platforms (CDPs)](#customer-data-platforms-cdps) like [Segment](https://segment.com/): Go into your CDP settings to add Mixpanel as a destination, and point your data stream to Mixpanel
+- [Import API](#import-api): Point your event ingestion pipeline to [Mixpanel’s robust API](https://developer.mixpanel.com/reference/import-events) for data ingestion
+- [Reverse ETL](#reverse-etl-retl) (RETL) tools like [Census](https://getcensus.com): Go into your RETL settings to add Mixpanel as a destination, and point your syncs to Mixpanel
 
 ### Client-side SDKs & Server-side SDKs
     
@@ -213,7 +211,7 @@ curl --request POST \
 The big difference between the APIs are:
 
 - **Authentication:** Amplitude authenticates in the request payload, whereas Mixpanel uses your project token in the request URL alongside basic auth. Mixpanel authentication can be done via a service account as described [here](https://developer.mixpanel.com/reference/ingestion-api-authentication). Be sure to move the authentication outside the payload.
-- **Event JSON Structure:** Amplitude and Mixpanel have slightly different structures (explained [here](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#differences-in-the-data-models)). You will want to remap the Amplitude event format to the expected Mixpanel JSON payload as described [here](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da).
+- **Event JSON Structure:** Amplitude and Mixpanel have slightly different structures (explained [here](/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-amplitude#differences-in-the-data-models)). You will want to remap the Amplitude event format to the expected Mixpanel JSON payload as described [here](https://www.notion.so/Migrating-to-Mixpanel-from-Amplitude-723407166fbf4f7ba9365034691502da).
 
 ### Reverse ETL (RETL)
 

--- a/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics.md
+++ b/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics.md
@@ -1,15 +1,13 @@
-# Migrating to Mixpanel from Google Analytics
-
-If you haven't already, we recommend starting with our [Migration Guides Overview](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Google Analytics.
+If you haven't already, we recommend starting with our [Migration Guides Overview](/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Google Analytics.
 
 ## Differences in the data models
 
 Mixpanel’s data model is based on events and properties, rather than sessions. While this might be a shift if you come from the sessions-based model, we’ve found it to be both more flexible and easier to set up and use.
 
-- [Events](https://docs.mixpanel.com/docs/getting-started/what-is-mixpanel#events) capture granular user actions, like a Pageview, Signup, or Purchase.
-- [Properties](https://docs.mixpanel.com/docs/getting-started/what-is-mixpanel#properties) capture attributes of those events, like which page was viewed, the UTM Campaign that led to a Signup, or the Item that was purchased.
+- [Events](/docs/getting-started/what-is-mixpanel#events) capture granular user actions, like a Pageview, Signup, or Purchase.
+- [Properties](/docs/getting-started/what-is-mixpanel#properties) capture attributes of those events, like which page was viewed, the UTM Campaign that led to a Signup, or the Item that was purchased.
 
-Events let you get more granular than [sessions](https://docs.mixpanel.com/docs/analysis/advanced/sessions), so that you can deeply understand user behavior. At the same time, Mixpanel automatically constructs sessions from events, so you can answer session-level questions too.
+Events let you get more granular than [sessions](/docs/analysis/advanced/sessions), so that you can deeply understand user behavior. At the same time, Mixpanel automatically constructs sessions from events, so you can answer session-level questions too.
 
 ## Currently using Universal Analytics with Google?
 
@@ -44,7 +42,7 @@ We recommend the following steps to get started quickly:
 - Use the [Mixpanel Marketing KPI Template](https://mixpanel.com/project?show-template-selector=true) to build your initial board
     
 #### Google Tag Manager (GTM)
-Mixpanel has a [Google Tag Manager (GTM) custom template]([https://help.mixpanel.com/hc/en-us/articles/4870177097748-Implementing-Mixpanel-with-Google-Tag-Manager](https://docs.mixpanel.com/docs/tracking/integrations/google-tag-manager)) which can be leveraged to implement events within an hour. The template initializes the Mixpanel JavaScript SDK with similar calls as outlined in the above section.
+Mixpanel has a [Google Tag Manager (GTM) custom template](/docs/tracking/integrations/google-tag-manager) which can be leveraged to implement events within an hour. The template initializes the Mixpanel JavaScript SDK with similar calls as outlined in the above section.
     
 We recommend setting up the following in the custom template to get started quickly: a) Choose to auto-track pages, b) Set your conversion events. Once done, Mixpanel will start receiving page views and key conversion events.
     
@@ -76,7 +74,7 @@ To backfill data, we recommend:
     - Utilize the CDPs backfilling feature, like [Segment Replay](https://segment.com/docs/guides/what-is-replay/), to re-send historical data to Mixpanel
 - For any other implementation method
     - First, export your data to the data warehouse so you have a record of Universal Analytics
-    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](https://docs.mixpanel.com/docs/tracking/how-tos/events-and-properties) Mixpanel expects
+    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](/docs/tracking/how-tos/events-and-properties) Mixpanel expects
     - Leverage our [Import API](https://developer.mixpanel.com/reference/import-events) to send us the formatted events from your data warehouse
 
 The process of importing old data with a different format has many potential issues - identity management, data discrepancies, etc. - as Mixpanel is fundamentally different than UA. It may be worth considering your use cases for importing old data before proceeding, as matching users and data across the systems can be time consuming. [Mixpanel Support](https://mixpanel.com/get-support) is here to help if you need advice how to go about importing the historical data.
@@ -177,7 +175,7 @@ Keep in mind that you will need to initialize the [Mixpanel SDK](https://develop
     
 #### Google Tag Manager (GTM)
 
-Mixpanel has a [Google Tag Manager (GTM) custom template](https://docs.mixpanel.com/docs/tracking/integrations/google-tag-manager) which can be leveraged to implement events within an hour. Simply load the template, and you can send Mixpanel the same events you’ve setup for your GA4 instance.
+Mixpanel has a [Google Tag Manager (GTM) custom template](/docs/tracking/integrations/google-tag-manager) which can be leveraged to implement events within an hour. Simply load the template, and you can send Mixpanel the same events you’ve setup for your GA4 instance.
 
 This method is straightforward since you’ve already setup your SDK to track “events” and are using Google Tag Manager. You can leverage this same setup to implement Mixpanel.
     
@@ -212,7 +210,7 @@ To backfill data, we recommend:
     - Utilize the CDPs backfilling feature, like [Segment Replay](https://segment.com/docs/guides/what-is-replay/), to re-send historical data to Mixpanel
 - For any other implementation method
     - First, export your data to the data warehouse so you have a record of Universal Analytics
-    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](https://docs.mixpanel.com/docs/tracking/how-tos/events-and-properties) Mixpanel expects
+    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](/docs/tracking/how-tos/events-and-properties) Mixpanel expects
     - Leverage our [Import API](https://developer.mixpanel.com/reference/import-events) to send us the formatted events from your data warehouse
 
 [Mixpanel Support](https://mixpanel.com/get-support) is here to help if you need advice how to go about importing the historical data.

--- a/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics.md
+++ b/pages/docs/other-bits/tutorials/migration-guides/migrating-to-mixpanel-from-google-analytics.md
@@ -1,206 +1,218 @@
 # Migrating to Mixpanel from Google Analytics
 
+If you haven't already, we recommend starting with our [Migration Guides Overview](https://docs.mixpanel.com/docs/other-bits/tutorials/migration-guides) as it details the key components of migrating to Mixpanel from other analytics tools. Below we outline specific steps and considerations when migrating from Google Analytics.
+
+## Differences in the data models
+
 Mixpanel’s data model is based on events and properties, rather than sessions. While this might be a shift if you come from the sessions-based model, we’ve found it to be both more flexible and easier to set up and use.
 
-- An [event](https://help.mixpanel.com/hc/en-us/articles/360041995352-Mixpanel-Concepts-Events) captures a granular user action, like a Pageview, Signup, or Purchase.
-- [Properties](https://help.mixpanel.com/hc/en-us/articles/360041995352-Mixpanel-Concepts-Events#event-properties) capture attributes of those events, like which page was viewed, the UTM Campaign that led to a Signup, or the Item that was purchased.
+- [Events](https://docs.mixpanel.com/docs/getting-started/what-is-mixpanel#events) capture granular user actions, like a Pageview, Signup, or Purchase.
+- [Properties](https://docs.mixpanel.com/docs/getting-started/what-is-mixpanel#properties) capture attributes of those events, like which page was viewed, the UTM Campaign that led to a Signup, or the Item that was purchased.
 
-Events let you get more granular than [sessions](https://help.mixpanel.com/hc/en-us/articles/115004695223), so that you can deeply understand user behavior. At the same time, Mixpanel automatically constructs sessions from events, so you can answer session-level questions too.
-
-Read on to learn how to migrate to Mixpanel’s modern, event-based model.
+Events let you get more granular than [sessions](https://docs.mixpanel.com/docs/analysis/advanced/sessions), so that you can deeply understand user behavior. At the same time, Mixpanel automatically constructs sessions from events, so you can answer session-level questions too.
 
 ## Currently using Universal Analytics with Google?
 
-### Part 1: Track forward looking real-time data
+### Track forward looking real-time data
 
 Choose your current implementation method for Universal Analytics (UA) and you can follow the below steps for starting to send live data to Mixpanel.
-​
-- **Client-side SDKs & Server-side SDKs:** You’ll have to setup Mixpanel fresh given Mixpanel leverages an event-based model that does not exist in Universal Analytics. The good news is you can get started within an hour, which is lesser or equivalent work to setting up GA4.
+
+#### Client-side SDKs & Server-side SDKs
+You’ll have to setup Mixpanel fresh given Mixpanel leverages an event-based model that does not exist in Universal Analytics. The good news is you can get started within an hour, which is lesser or equivalent work to setting up GA4 from an SDK perspective, since both need a fresh implementation to be setup on an “events” model vs UA’s “sessions” model.
     
-    We recommend the following steps to get started quickly:
+We recommend the following steps to get started quickly:
+
+- Configure the [Mixpanel JavaScript SDK](https://developer.mixpanel.com/docs/javascript-full-api-reference) to automatically track page views, where UTM params are tracked by default
+
+    ```jsx
+    mixpanel.init('YOUR_TOKEN', {track_pageview: true});
+    ```
+
+- Track a few key conversion events of interest
+
+    ```jsx
+    // Send a "Played song" event to Mixpanel
+    // with a property "genre"
+    mixpanel.track(
+        "Played song",
+        {
+            "genre": "hip-hop"
+        }
+    );
+    ```
+
+- Use the [Mixpanel Marketing KPI Template](https://mixpanel.com/project?show-template-selector=true) to build your initial board
     
-    - Configure the [Mixpanel JavaScript SDK](https://developer.mixpanel.com/docs/javascript-full-api-reference) to automatically track page views, where UTM params are tracked by default
-        
-        ```jsx
-        mixpanel.init('YOUR_TOKEN', {track_pageview: true});
-        ```
-        
-    - Track a few key conversion events of interest
-        
-        ```jsx
-        // Send a "Played song" event to Mixpanel
-        // with a property "genre"
-        mixpanel.track(
-        	"Played song",
-        	{
-        		"genre": "hip-hop"
-        	}
-        );
-        ```
-        
-    - Use the [Mixpanel Marketing KPI Template](https://mixpanel.com/project?show-template-selector=true) to build your initial board
+#### Google Tag Manager (GTM)
+Mixpanel has a [Google Tag Manager (GTM) custom template]([https://help.mixpanel.com/hc/en-us/articles/4870177097748-Implementing-Mixpanel-with-Google-Tag-Manager](https://docs.mixpanel.com/docs/tracking/integrations/google-tag-manager)) which can be leveraged to implement events within an hour. The template initializes the Mixpanel JavaScript SDK with similar calls as outlined in the above section.
     
-    It’s equal effort to set up GA4 or set up Mixpanel from an SDK perspective, since both need a fresh implementation to be setup on an “events” model vs UA’s “sessions” model.
+We recommend setting up the following in the custom template to get started quickly: a) Choose to auto-track pages, b) Set your conversion events. Once done, Mixpanel will start receiving page views and key conversion events.
     
-- **Google Tag Manager (GTM):** Mixpanel has a [Google Tag Manager (GTM) custom template](https://help.mixpanel.com/hc/en-us/articles/4870177097748-Implementing-Mixpanel-with-Google-Tag-Manager) which can be leveraged to implement events within an hour. The template initializes the Mixpanel JavaScript SDK with similar calls as outlined in the above section.
+#### Customer Data Platforms (CDPs)
+CDPs like [Segment](https://segment.com/) have always tracked event data and synthesized them into sessions for Universal Analytics. You can add Mixpanel as a destination to your CDP and immediately start receiving the same data as your other destinations.
     
-    We recommend setting up the following in the custom template to get started quickly: a) Choose to auto-track pages, b) Set your conversion events. Once done, Mixpanel will start receiving page views and key conversion events.
-    
-- **Customer Data Platforms (CDPs) like [Segment](https://segment.com/):** CDPs have always tracked event data and synthesized them into sessions for Universal Analytics. You can add Mixpanel as a destination to your CDP and immediately start receiving the same data as your other destinations.
-    
-    Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination.
-    
-    Once you set up the connection to Mixpanel, you can proceed with configuring key settings like:
-    
-    - which events and properties to send → only send what matters
-    - edit any mappings/editing/filtering that has to be done on the data → ensure high data quality and governance
-    - connection settings, or CDP specific settings for data syncs → control over how data is sent
-    
-    We provide Mixpanel as a destination and setup guides for all of the most popular CDPs:
-    
-    - [Segment](https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/)
-    - [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
-    - [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
-​
-### Part 2: Loading Historical Data
-​
-For most cases, we recommend starting fresh. In the cases where historical data is essential, we recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
-​
+Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination:
+
+![Segment Connection](https://user-images.githubusercontent.com/129823695/234812593-dffee962-bb34-49b8-9686-96bc0f0565d8.png)
+
+Once you set up the connection to Mixpanel, you can proceed with configuring key settings like:
+
+- Which events and properties to send → only send what matters
+- Edit any mappings/editing/filtering that has to be done on the data → ensure high data quality and governance
+- Connection settings, or CDP specific settings for data syncs → control over how data is sent
+
+We provide Mixpanel as a destination and setup guides for all of the most popular CDPs:
+
+- [Segment](https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/)
+- [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
+- [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
+
+### Loading historical data
+
+For most cases, we recommend starting fresh when migrating from UA. In the cases where historical data is essential, we recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
+
 To backfill data, we recommend:
-​
 - If you have a CDP, this should be straightforward
     - Utilize the CDPs backfilling feature, like [Segment Replay](https://segment.com/docs/guides/what-is-replay/), to re-send historical data to Mixpanel
 - For any other implementation method
     - First, export your data to the data warehouse so you have a record of Universal Analytics
-    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](https://developer.mixpanel.com/reference/import-events#example-of-an-event) Mixpanel expects
+    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](https://docs.mixpanel.com/docs/tracking/how-tos/events-and-properties) Mixpanel expects
     - Leverage our [Import API](https://developer.mixpanel.com/reference/import-events) to send us the formatted events from your data warehouse
-​
-It is also recommended you load the historical data into a test project with a limited subset (for ex, a single day of data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
-​
-The process of importing old data with a different format has many potential issues - identity management, data discrepancies, etc. - as Mixpanel is fundamentally different than UA. It may be worth considering your use cases for importing old data before proceeding, as matching users and data across the systems can be time consuming. [Mixpanel Support](mailto:support@mixpanel.com) is here to help if you need advice how to go about importing the historical data.
-​
+
+The process of importing old data with a different format has many potential issues - identity management, data discrepancies, etc. - as Mixpanel is fundamentally different than UA. It may be worth considering your use cases for importing old data before proceeding, as matching users and data across the systems can be time consuming. [Mixpanel Support](https://mixpanel.com/get-support) is here to help if you need advice how to go about importing the historical data.
+
 ## Currently using GA4 and not seeing value?
-​
-### Part 1: Track forward looking real-time data
-​
+
+### Track forward looking real-time data
+
 Choose your current implementation method for Google Analytics (GA4) and you can follow the below steps for starting to send live data to Mixpanel.
-​
-- **Client-side SDKs & Server-side SDKs:** Mixpanel and GA4’s client-side SDKs have *very similar* developer facing APIs. This makes it fairly easy to “find and replace” embedded GA4 calls and swap them for Mixpanel calls.
+
+#### Client-side SDKs & Server-side SDKs
+
+Mixpanel and GA4’s client-side SDKs have *very similar* developer facing APIs. This makes it fairly easy to “find and replace” embedded GA4 calls and swap them for Mixpanel calls.
     
-    This section will detail the Javascript SDKs (for the sake of brevity), although both analytics platforms have fairly uniform tracking APIs for other SDKs (mobile, server-side, etc.)
+This section will detail the Javascript SDKs (for the sake of brevity), although both analytics platforms have fairly uniform tracking APIs for other SDKs (mobile, server-side, etc.)
+
+##### Events
+
+GA4 method
+
+```jsx
+gtag('event', 'event_name', {
+    'param1': 'value1',
+    'param2': 'value2'
+});
+```
+
+Mixpanel method
+
+```jsx
+mixpanel.track('event_name', {
+    'param1': 'value1',
+    'param2': 'value2'
+});
+```
+
+##### Identity Management
+
+GA4 method
+
+```jsx
+gtag('config', 'GA_MEASUREMENT_ID', {
+    'user_id': 'USER_ID'
+});
+```
+
+Mixpanel method
+
+```jsx
+mixpanel.identify('USER_ID');
+```
+
+##### User Properties
+
+GA4 method
+
+```jsx
+gtag('set', 'user_properties', {
+    'property1': 'value1',
+    'property2': 'value2'
+});
+```
+
+Mixpanel method
+
+```jsx
+mixpanel.people.set({
+    'property1': 'value1',
+    'property2': 'value2'
+});
+```
+
+##### Super Properties
+
+GA4 method → GA4 doesn't have a direct equivalent, but you can set global properties on the SDK config we recommend moving to Mixpanel
+
+```jsx
+gtag('config', 'GA_MEASUREMENT_ID', {
+    'custom_map': {
+        'dimension1': 'property1',
+        'dimension2': 'property2'
+    },
+    'property1': 'value1',
+    'property2': 'value2'
+});
+```
+
+Mixpanel method
+
+```jsx
+mixpanel.register({
+    'property1': 'value1',
+    'property2': 'value2'
+});
+```
+
+Keep in mind that you will need to initialize the [Mixpanel SDK](https://developer.mixpanel.com/docs/javascript-full-api-reference) by adding the Mixpanel snippet to your website before using these tracking calls. Replace the placeholders (e.g., 'event_name', 'USER_ID', 'value1', etc.) with the appropriate values from GA4 in your code as you migrate the code.
     
-    **Events**
+#### Google Tag Manager (GTM)
+
+Mixpanel has a [Google Tag Manager (GTM) custom template](https://docs.mixpanel.com/docs/tracking/integrations/google-tag-manager) which can be leveraged to implement events within an hour. Simply load the template, and you can send Mixpanel the same events you’ve setup for your GA4 instance.
+
+This method is straightforward since you’ve already setup your SDK to track “events” and are using Google Tag Manager. You can leverage this same setup to implement Mixpanel.
     
-    GA4 method
+#### Customer Data Platforms (CDPs)
+
+CDPs like [Segment](https://segment.com/) will already be tracking events to GA4 that you want to duplicate to Mixpanel. You can add Mixpanel as a destination to your CDP and immediately start receiving the same data as your other destinations.
     
-    ```jsx
-    gtag('event', 'event_name', {
-    	'param1': 'value1',
-    	'param2': 'value2'
-    });
-    ```
+CDPs like [Segment](https://segment.com/) have always tracked event data and synthesized them into sessions for Universal Analytics. You can add Mixpanel as a destination to your CDP and immediately start receiving the same data as your other destinations.
     
-    Mixpanel method
-    
-    ```jsx
-    mixpanel.track('event_name', {
-    	'param1': 'value1',
-    	'param2': 'value2'
-    });
-    ```
-    
-    **Identity Management**
-    
-    GA4 method
-    
-    ```jsx
-    gtag('config', 'GA_MEASUREMENT_ID', {
-    	'user_id': 'USER_ID'
-    });
-    ```
-    
-    Mixpanel method
-    
-    ```jsx
-    mixpanel.identify('USER_ID');
-    ```
-    
-    **User Properties**
-    
-    GA4 method
-    
-    ```jsx
-    gtag('set', 'user_properties', {
-    	'property1': 'value1',
-    	'property2': 'value2'
-    });
-    ```
-    
-    Mixpanel method
-    
-    ```jsx
-    mixpanel.people.set({
-    	'property1': 'value1',
-    	'property2': 'value2'
-    });
-    ```
-    
-    **Super Properties**
-    
-    GA4 method → GA4 doesn't have a direct equivalent, but you can set global properties on the SDK config we recommend moving to Mixpanel
-    
-    ```jsx
-    gtag('config', 'GA_MEASUREMENT_ID', {
-    	'custom_map': {
-    		'dimension1': 'property1',
-    		'dimension2': 'property2'
-    	},
-    	'property1': 'value1',
-    	'property2': 'value2'
-    });
-    ```
-    
-    Mixpanel method
-    
-    ```jsx
-    mixpanel.register({
-    	'property1': 'value1',
-    	'property2': 'value2'
-    });
-    ```
-    
-    Keep in mind that you will need to initialize the [Mixpanel SDK](https://developer.mixpanel.com/docs/javascript-full-api-reference) by adding the Mixpanel snippet to your website before using these tracking calls. Replace the placeholders (e.g., 'event_name', 'USER_ID', 'value1', etc.) with the appropriate values from GA4 in your code as you migrate the code.
-    
-- **Google Tag Manager (GTM):** Mixpanel has a [Google Tag Manager (GTM) custom template](https://help.mixpanel.com/hc/en-us/articles/4870177097748-Implementing-Mixpanel-with-Google-Tag-Manager) which can be leveraged to implement events within an hour. Simply load the template, and you can send Mixpanel the same events you’ve setup for your GA4 instance.
-    
-    This method is straightforward since you’ve already setup your SDK to track “events” and are using Google Tag Manager. You can leverage this same setup to implement Mixpanel.
-    
-- **Customer Data Platforms (CDPs) like [Segment](https://segment.com/):**  CDPs will already be tracking events to GA4 that you want to duplicate to Mixpanel. You can add Mixpanel as a destination to your CDP and immediately start receiving the same data as your other destinations.
-    
-    Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination. Once you set up the connection to Mixpanel, you can proceed with configuring key settings like:
-    - which events and properties to send → only send what matters
-    - edit any mappings/editing/filtering that has to be done on the data → ensure high data quality and governance
-    - connection settings, or CDP specific settings for data syncs → control over how data is sent
-    
-    We provide Mixpanel as a destination and setup guides for all of the most popular CDPs:
-    
-    - [Segment](https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/)
-    - [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
-    - [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
-​
-### Part 2: Loading Historical Data
-​
-For most cases, we recommend starting fresh. In the cases where historical data is essential, we recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
-​
+Since CDPs already collect all your data via 1 SDK and route to many downstream destinations, enabling Mixpanel is straightforward. Simply go to your CDP settings and add Mixpanel as a destination:
+
+![Segment Connection](https://user-images.githubusercontent.com/129823695/234812593-dffee962-bb34-49b8-9686-96bc0f0565d8.png)
+
+Once you set up the connection to Mixpanel, you can proceed with configuring key settings like:
+
+- Which events and properties to send → only send what matters
+- Edit any mappings/editing/filtering that has to be done on the data → ensure high data quality and governance
+- Connection settings, or CDP specific settings for data syncs → control over how data is sent
+
+We provide Mixpanel as a destination and setup guides for all of the most popular CDPs:
+
+- [Segment](https://segment.com/docs/connections/destinations/catalog/actions-mixpanel/)
+- [mParticle](https://docs.mparticle.com/integrations/mixpanel/audience/)
+- [Rudderstack](https://www.rudderstack.com/docs/destinations/streaming-destinations/mixpanel/)
+
+### Loading historical data
+
+Given GA4 has a similar data format to Mixpanel, it is possible to migrate some of your historical data to see trends. In the cases where historical data is essential, we recommend loading a year’s worth (or less) of historical data during your migration. This will allow your team to review year-over-year trends easily and do historical analysis as needed.
+
 To backfill data, we recommend:
-​
 - If you have a CDP, this should be straightforward
     - Utilize the CDPs backfilling feature, like [Segment Replay](https://segment.com/docs/guides/what-is-replay/), to re-send historical data to Mixpanel
 - For any other implementation method
-    - First, export your data to BigQuery (provided for free with GA4) so you have a record of the data
-    - Since GA4 data is events (and not sessions), the data exported to BigQuery should already be [formatted for Mixpanel](https://developer.mixpanel.com/reference/import-events#example-of-an-event)
-    - Then leverage the [Import API](https://developer.mixpanel.com/reference/import-events) or a [Reverse ETL](https://mixpanel.com/blog/what-is-reverse-etl-product-data/) tool like [Census](https://getcensus.com/) to import to Mixpanel
-​
-It is also recommended you load the historical data into a test project with a limited subset (for ex, a single day of data or a sample of the entire dataset) to get started. This will help you identify any errors in the end to end process before you do a full historical data load.
-​
-[Mixpanel Support](mailto:support@mixpanel.com) is here to help if you need advice how to go about importing the historical data.
+    - First, export your data to the data warehouse so you have a record of Universal Analytics
+    - Once exported, your data warehouse tables can be transformed and modeled into the [event format](https://docs.mixpanel.com/docs/tracking/how-tos/events-and-properties) Mixpanel expects
+    - Leverage our [Import API](https://developer.mixpanel.com/reference/import-events) to send us the formatted events from your data warehouse
+
+[Mixpanel Support](https://mixpanel.com/get-support) is here to help if you need advice how to go about importing the historical data.


### PR DESCRIPTION
Moving information consistent across migrations to overview section, and cleaning up the provider specific guides from initial import from Notion (formatting, links, navigation, etc.)