### PR TITLE
Fix broken images

### DIFF
--- a/pages/docs/analysis/advanced/sessions.md
+++ b/pages/docs/analysis/advanced/sessions.md
@@ -27,21 +27,21 @@ Project Admins or Owners can change a project's session definition in Project Se
 
 In [Funnels](/docs/analysis/reports/funnels), once you have set up sessions, a “Session Start” and “Session End” event will be generated in the report based on the funnel criteria.
 
-![/mceclip7.png](/mceclip7.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/e6c12438-00da-4ebe-8302-a52f5a9da511)
 
 The event properties "Session Duration (Seconds)", "Session Event Count", "Session End Event Name", and "Session Start Event Name" can be used to breakdown or filter these results.
 
-![/mceclip8.png](/mceclip8.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/5608f64b-3514-406f-8a65-fe6a588f36fb)
 
 You can also choose to count Sessions instead of Uniques or Totals in the Conversion Details section. If you choose to count Sessions, the conversion window will be limited to one session.
 
 Whenever you make a change to session settings, you can then review the impact of this change in the Funnels Time to Convert Chart. If you see a large group of users doing 4+ hour sessions or just having sessions of <1 minute, you can create cohorts from these user segments and then evaluate their behavior in Flows to confirm Sessions is set up correctly.
 
-![/mceclip9.png](/mceclip9.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/e986f4f1-ad96-408b-8217-2a979b66e9eb)
 
 If you choose to count Uniques or Totals, you will be able to select a conversion window as usual, including Sessions.
 
-![/mceclip15.png](/mceclip15.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/d0be7cb4-9cd4-46cd-849e-af4687b6aa1c)
 
 ### Flows
 
@@ -59,7 +59,7 @@ In [Insights](/docs/analysis/reports/insights), you can use the “Session Star
 - The average number of sessions per user
 - Sessions calculated in formulas
 
-![/mceclip12.png](/mceclip12.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/ee999c27-c70f-438e-a95d-6ea4925b8474)
 
 When you select sessions in Insights, you will be viewing total sessions counts, rather than uniques or totals.
 
@@ -69,7 +69,7 @@ The event properties "Session Duration (Seconds)", "Session Event Count", "Sessi
 
 In Insights, you can also count the number of sessions that contained a particular event. Select the **Total** drop down beside an event in your Insights query to select **Sessions**.
 
-![/mceclip14.png](/mceclip14.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/350c4606-4366-40af-a050-21cbe01bf543)
 
 For example, select an event which determines success for your company, such as "Product Purchase". Using this aggregation you can track how many sessions contained a purchase.
 
@@ -105,9 +105,9 @@ Sessions are reset every 24 hours at midnight (according to your project timezon
 
 Use your [Time to Convert Chart in Funnels](/docs/analysis/reports/funnels#time-to-convert) to help determine an appropriate session timeout period that aligns with your users’ behavior.
 
-![/mceclip6.png](/mceclip6.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/44f40194-1aff-493b-828e-f9a1c750ac03)
 
-![/mceclip5.png](/mceclip5.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/2e831c9f-d3cc-4dcf-abb9-a741e22de34d)
 
 In your Funnel you can select the event that denotes a "Session Start" in your app (such as “Log In”), and the "Session End" event (such as “Log Out”). Check the time it takes users to convert from the start event to the end event in the Time to Convert Chart, and this will give you an indicator of the average amount of time a session lasts in your app.
 

--- a/pages/docs/analysis/advanced/signal.md
+++ b/pages/docs/analysis/advanced/signal.md
@@ -1,12 +1,3 @@
----
-title: "Signal"
-slug: "signal"
-hidden: false
-metadata:
-  title: "Signal"
-  description: "Learn about Mixpanel Signal report."
----
-
 ## Overview
 
 Signal measures the association between a correlation event and a goal event and quantifies the correlation between the two. This facilitates a deeper understanding of the behaviors that drive customer conversions, and can help guide product decisions.
@@ -19,11 +10,11 @@ The music sharing app may want to understand the correlation between top events 
 
 Building this query in Signal would involve selecting the target users, and how the "Song Purchased" goal event is correlated with the top events.
 
-![/mceclip0.png](/mceclip0.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/2baec3b5-ce5e-4d7d-9726-de131d05bfd2)
 
 Values are returned after running the correlation. “Song Played” could have a strong positive correlation with purchasing a song. Most of the users who played a song later purchased a song.
 
-![/Screen_Shot_2018-07-13_at_9.19.24_AM.png](/Screen_Shot_2018-07-13_at_9.19.24_AM.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/3409f91a-ca07-4cd0-84c4-9105ee9024a0)
 
 This information can be used in future product decisions. By knowing that those who play songs are more likely to purchase songs, it is possible to build tools to encourage song plays. This could lead to a dramatic increase in the amount of users purchasing songs.
 

--- a/pages/docs/analysis/reports.md
+++ b/pages/docs/analysis/reports.md
@@ -117,7 +117,7 @@ If you need to, you can click on the **+ Ending** button and shift back the de
 
 You can choose to filter the entire report by properties or cohorts by clicking the **Filter** button. This will filter the results of the entire report to show only data with that property or cohort.
 
-![/mceclip4.png](/mceclip4.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/41eb81c5-cab0-4c1d-96f4-97f5868f3123)
 
 ### Event Inline Filters
 
@@ -125,11 +125,11 @@ You can choose to add a filter to limit the events that are included in the repo
 
 Add a filter to your query by clicking on the **…** icon beside an event, profile, cohort, or step.
 
-![/mceclip0.png](/mceclip0.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/3e36bd7e-f5b8-462a-890c-bf396ff98f69)
 
 Then, select a property from the drop down list that appears and specify which values to filter.
 
-![/mceclip2.png](/mceclip2.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/c7cce429-3c9c-4759-8ea1-b09345fa0b4e)
 
 In Funnels, filtering a step by a particular property will limit the data you see in the funnel to events with that property value.
 
@@ -137,7 +137,7 @@ You can choose multiple property filters for each item in your query.
 
 You can select whether you would like the query to match any of these filters, or all of the filters by clicking on **and/or** beside the filters.
 
-![/mceclip3.png](/mceclip3.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/9e3bcd31-2b12-48d1-b04f-cdda85dd2584)
 
 ### Breakdowns
 
@@ -147,7 +147,7 @@ This feature is useful for determining if a group factor, such as browser type, 
 
 Select the **Breakdown** button, and select the property or cohort you want to breakdown your results by.
 
-![/mceclip5.png](/mceclip5.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/65ee0e74-f5ec-4d30-afdc-f4516ed0d845)
 
 For cohorts, you will be shown groups of users both in and not in the cohort in your results.
 

--- a/pages/docs/analysis/reports/flows.md
+++ b/pages/docs/analysis/reports/flows.md
@@ -213,7 +213,7 @@ Top paths will show the 50 most common event sequences of up to the number of st
 
 The total percentage of users who reached the ultimate destination of a flow is indicated on the top left, while the total users that reached a given step and the percentage of users who converted from the previous step are indicated on the bottom of each step.
 
-![/mceclip0.png](/mceclip0.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/c36fcfb5-edbb-4374-86fc-6e3d3f5aa316)
 
 ### Expand Event by Property
 

--- a/pages/docs/analysis/reports/funnels.md
+++ b/pages/docs/analysis/reports/funnels.md
@@ -177,15 +177,15 @@ Exclusion steps operate as a "did not do" filter for funnels. This provides the
 
 At the "Conversion Criteria" section, click on "Advanced" and then on "Exclude users who did...". A dropdown will appear to exclude a step from your funnel.
 
-![/mceclip0__2_.png](/mceclip0__2_.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/fc146839-6feb-4a40-a7b7-c17217bf6c7a)
 
 Select an event from the list and choose whether you would like the event to be excluded between all steps, or between specific steps.
 
-![/mceclip1.png](/mceclip1.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/d1c95913-42ca-45ba-9605-5cce51534e48)
 
 Click the **Filter icon** beside the step to filter that event by an event or user profile property.
 
-![/mceclip2__1_.png](/mceclip2__1_.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/ab63bef8-3d64-4b4b-97ed-392811e185ac)
 
 For example, if your product was an e-commerce retail company and you want to understand if users who browse for additional products between adding something to their cart and checking out are less likely to complete a purchase. To answer this question, you could create a funnel with three steps:
 
@@ -211,11 +211,11 @@ Note:
 
 Click on the "three dots" icon beside a step and click **Rename** to rename it.
 
-![/mceclip3__1_.png](/mceclip3__1_.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/2e2e844b-a9f6-4eb1-8532-345c7e8613e3)
 
 ### View as Flow
 
-In order to learn more about the behavior users take between funnel steps, we recommend checking the feature "View as Flow". You can see what user flows and behaviors that can increase the likelihood of conversion or dropoff. This helps to answer questions like:
+In order to learn more about the behavior users take between funnel steps, use "View as Flow". You can see what user flows and behaviors that can increase the likelihood of conversion or dropoff. This helps to answer questions like:
 
 - What flows do users take between opening an app and making a purchase?
 - Why did the successful users purchase?
@@ -223,7 +223,7 @@ In order to learn more about the behavior users take between funnel steps, we re
 - How do these two paths differ? What actions should I nudge towards or against?
 - What did the users that dropped-off do instead?
 
-![/mceclip19.png](/mceclip19.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/b37e48d4-d9c8-42b7-9e79-72e7e71e47eb)
 
 #### Using Conversion and Drop-off Flows
 
@@ -283,7 +283,7 @@ Select **Funnel trends** from the drop-down list to see the percentage of succ
 
 A user that completes the funnel within the conversion window is counted on the day, week, or month corresponding to when they performed the first event in the funnel.
 
-![/mceclip0.png](/mceclip0.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/10e15262-5d2f-4b77-80e2-3a7270645878)
 
 By default this chart shows the conversion rate. Click on **Conversion** to view the options Time to Convert, Top of Funnel, and Bottom of Funnel.
 
@@ -295,7 +295,7 @@ Trends charts in Funnels are accompanied with a table of values to give users an
 
 Click on a "data column" header to sort by that column. Click the header again to reverse the sort order. The table below is sorted by event counts on August 2nd:
 
-![/mceclip0__1_.png](/mceclip0__1_.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/c5b5a712-4369-4c4b-831c-246c61c30bc5)
 
 #### Time to Convert Trend
 
@@ -517,25 +517,25 @@ Consider a four-step funnel where a user must Search > Item Detail Page > Add to
 
 As you can see in the below activity feed, this user's first Search event happens more than one day before any Item Detail Pages, and as such, they would not convert in this funnel.
 
-![/mceclip12.png](/mceclip12.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/5d671e0b-5666-4ec5-971a-cfaf3734929a)
 
-![/mceclip11.png](/mceclip11.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/eb848af7-4cef-4eb5-8a60-36c88a6fd64f)
 
 However, if I put a per step filter on the Search event and require a user to use a Brower = Safari, then I will restrict entry into the funnel to only Search events on Safari browsers.
 
 Below we see the same user's activity stream where their first Search event is with the Chrome browser, and thus this user’s first Search event **is not** included in a funnels calculation. However they have a second Search that is using Safari, and this event qualifies them to enter into the funnel. Unlike before when we did not filter, now each of their subsequent steps happens within the conversion window, and this user reaches full conversion to the end of the funnel.
 
-![/mceclip14.png](/mceclip14.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/6daf8f38-afaf-48dd-994e-7f7be682cc92)
 
-![/mceclip13.png](/mceclip13.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/a025b018-cecc-4798-9b95-b907ad157b5e)
 
 If we were to take it further and place a per-step filter on each and every step in this funnel, so that all steps must be completed with events where Browser = Safari, then this user would only convert to the second step of the Item Detail.
 
 This is because, as we can see below, the first Search/Safari step is followed by two steps that aren’t tracked in the funnel: *Item Detail Page/Chrome* that is filtered out of this funnel because it does not fulfill the Browser= Safari criteria, and *Add to Cart/Safari* that is not considered because it is not preceded by an Item Detail Page/Safari. The next step that is tracked in the funnel (Item Detail Page/Safari) converts the user to Step 2, but then *Add to Cart/Chrome* is filtered out of the funnel. Since there is not another Add to Cart/Safari before the Purchase event or before the 1 day conversion window runs out, this user times out of the funnel after Step 2.
 
-![/mceclip15.png](/mceclip15.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/d2425bf0-5d61-4bf3-ad2f-861fa65f3563)
 
-![/mceclip16.png](/mceclip16.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/c91178bc-f358-44fd-ada8-ca786d690354)
 
 #### Global Filtering (Post-Query)
 
@@ -545,9 +545,9 @@ For example, let's use the same four-step funnel where a user must Seach > Item 
 
 In the below example, the Funnels query will calculate a conversion because the user moves from Search, then Item Detail Page, then Add to Cart and lastly to Purchase within the 1 day conversion window. However, after the query is calculated, the global filter of Browser = Safari is applied. Since there are steps of this calculated funnel that have Browser = Chrome, the entire funnel will be filtered out of the aggregate results.
 
-![/mceclip18.png](/mceclip18.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/ef83cca5-5108-4d06-a111-5c2b7e93a492)
 
-![/mceclip17.png](/mceclip17.png)
+![image](https://github.com/mixpanel/docs/assets/2077899/2335dc77-4dac-48d8-a56d-66deefadbc11)
 
 ### How does Mixpanel calculate statistical significance?
 


### PR DESCRIPTION
Bunch of images used relative paths like /mceclipX, which overlapped across docs and led to incorrect images being referenced in multiple places.

Replacing this with UUIDs so that they don't overlap