### PR TITLE
Remove requirement to pass API Secret to send data to Mixpanel

### DIFF
--- a/pages/docs/tracking/how-tos/ad-spend.md
+++ b/pages/docs/tracking/how-tos/ad-spend.md
@@ -196,9 +196,7 @@ const GOOGLE_ADS_CUSTOMER_ID = 'YOUR GOOGLE CUSTOMER CLIENT ID WITHOUT HYPHENS';
 
 // End of Configuration
 
-const mixpanel = Mixpanel.init(MIXPANEL_TOKEN, {
-    secret: MIXPANEL_SECRET
-});
+const mixpanel = Mixpanel.init(MIXPANEL_TOKEN);
 
 const client = new GoogleAdsApi({
     client_id: GOOGLE_CLIENT_ID,

--- a/pages/docs/tracking/how-tos/api-credentials.md
+++ b/pages/docs/tracking/how-tos/api-credentials.md
@@ -13,12 +13,13 @@ You can find it in the [Project Settings](https://mixpanel.com/settings/project)
 
 You can then use your token to track events to Mixpanel. See our guides for [Javascript](/docs/tracking/javascript-quickstart), [Server](/docs/tracking/server), and [Mobile](doc:mobile).
 
-Note: Project Token does not let you _read_ any data from your Mixpanel project. It only lets you track. This is intentional because your Project Token is public and shipped to client devices as part of your website's Javascript code.
+Note: Project Token does not let you _read_ any data from your Mixpanel project. It only lets you track. This is intentional because your Project Token is public and shipped to client devices as part of your website's Javascript code. or shared with 3rd parties, like CDPs.
 
 
 ## API Secret
-The API Secret is used to export data out of your project via our Export APIs. You can find it in the [Project Settings](https://mixpanel.com/settings/project) page under "Access Keys", right below Project Token.
+The API Secret is used to export data out of your project via our Export APIs. You can find it in the [Project Settings](https://mixpanel.com/settings/project) page under "Access Keys", right below Project Token. 
 
+You should not share your API Secret, since it can be used to export data from your Mixpanel project.
 
 ## Service Accounts
 [Service Accounts](https://developer.mixpanel.com/reference/service-accounts) are a more advanced form of authentication that is used to grant temporary access to a subset of Mixpanel projects within your organization for certain APIs.

--- a/pages/docs/tracking/how-tos/api-credentials.md
+++ b/pages/docs/tracking/how-tos/api-credentials.md
@@ -17,16 +17,10 @@ Note: Project Token does not let you _read_ any data from your Mixpanel project.
 
 
 ## API Secret
-The API Secret is used to backfill historical events into your project via our Import API and to export data out of your project via our Export APIs.
-
-You should not share your API Secret, since it can be used to export data from your Mixpanel project.
-
-
-You can find it in the [Project Settings](https://mixpanel.com/settings/project) page under "Access Keys", right below Project Token.
+The API Secret is used to export data out of your project via our Export APIs. You can find it in the [Project Settings](https://mixpanel.com/settings/project) page under "Access Keys", right below Project Token.
 
 
 ## Service Accounts
-
 [Service Accounts](https://developer.mixpanel.com/reference/service-accounts) are a more advanced form of authentication that is used to grant temporary access to a subset of Mixpanel projects within your organization for certain APIs.
 
 Service Accounts are not necessary to send data to Mixpanel or export data out of Mixpanel.

--- a/pages/docs/tracking/http-api.md
+++ b/pages/docs/tracking/http-api.md
@@ -5,10 +5,10 @@ hidden: false
 ---
 If you don't see an SDK or an integration in your language, you can send events to our API directly.
 
-Here's a sample script. Just plug in your API Secret at the top, run the script, and visit our [Events page](https://mixpanel.com/report/events) to see the events in our UI.
+Here's a sample script. Just plug in your Project Token at the top, run the script, and visit our [Events page](https://mixpanel.com/report/events) to see the events in our UI.
 ```python test.py
-# Fill this out. Note: this API requires the API Secret, not the Project Token
-API_SECRET = ""  # Get this from mixpanel.com/settings/project
+# Fill this out
+PROJECT_TOKEN = ""  # Get this from mixpanel.com/settings/project
 
 import json
 import time
@@ -22,7 +22,7 @@ events = [
 resp = requests.post(
     "https://api.mixpanel.com/import",
     params={"strict": "1"},
-    auth=(API_SECRET, ""),
+    auth=(PROJECT_TOKEN, ""),
     headers={"Content-Type": "application/json"},
     data=json.dumps(events)
 )

--- a/pages/docs/tracking/integrations/gcs-import.md
+++ b/pages/docs/tracking/integrations/gcs-import.md
@@ -46,9 +46,8 @@ import time
 from google.cloud import storage
 import requests
 
-PROJECT_ID = ""  # mixpanel.com/project/<YOUR_PROJECT_ID>
-USER = ""  # Service Account user
-PASS = ""  # Service Account password
+# Fill this out.
+PROJECT_TOKEN = ""
 
 # Flush a batch once these limits are hit
 EVENTS_PER_BATCH = 2000
@@ -71,13 +70,13 @@ def flush(batch):
     while True:
         resp = requests.post(
             "https://api.mixpanel.com/import",
-            params={"strict": "1", "project_id": PROJECT_ID},
+            params={"strict": "1"},
             headers={
                 "Content-Type": "application/x-ndjson",
                 "Content-Encoding": "gzip",
                 "User-Agent": "mixpanel-gcs"
             },
-            auth=(USER, PASS),
+            auth=(PROJECT_TOKEN, ""),
             data=payload,
         )
         if resp.status_code == 429 or resp.status_code >= 500:

--- a/pages/docs/tracking/integrations/google-pubsub.md
+++ b/pages/docs/tracking/integrations/google-pubsub.md
@@ -40,10 +40,8 @@ import time
 
 import requests
 
-
-PROJECT_ID = ""  # mixpanel.com/project/<YOUR_PROJECT_ID>
-USER = ""  # Service Account user
-PASS = ""  # Service Account password
+# Fill this out.
+PROJECT_TOKEN = ""
 
 
 def main(event, context):
@@ -63,8 +61,8 @@ def main(event, context):
     while True:
         resp = requests.post(
             "https://api.mixpanel.com/import",
-            params={"strict": "1", "project_id": PROJECT_ID},
-            auth=(USER, PASS),
+            params={"strict": "1"},
+            auth=(PROJECT_TOKEN, ""),
             headers={"Content-Type": "application/json", "Content-Encoding": "gzip", "User-Agent": "mixpanel-pubsub"},
             data=payload,
         )

--- a/pages/docs/tracking/integrations/s3-import.md
+++ b/pages/docs/tracking/integrations/s3-import.md
@@ -49,9 +49,8 @@ import boto3
 import requests
 
 
-PROJECT_ID = ""  # mixpanel.com/project/<YOUR_PROJECT_ID>
-USER = ""  # Service Account user
-PASS = ""  # Service Account password
+# Fill this out with your Project Token
+PROJECT_TOKEN = ""
 
 # Flush a batch once these limits are hit
 EVENTS_PER_BATCH = 2000
@@ -74,13 +73,13 @@ def flush(batch):
     while True:
         resp = requests.post(
             "https://api.mixpanel.com/import",
-            params={"strict": "1", "project_id": PROJECT_ID},
+            params={"strict": "1"},
             headers={
                 "Content-Type": "application/x-ndjson",
                 "Content-Encoding": "gzip",
                 "User-Agent": "mixpanel-s3"
             },
-            auth=(USER, PASS),
+            auth=(PROJECT_TOKEN, ""),
             data=payload,
         )
         if resp.status_code == 429 or resp.status_code >= 500:


### PR DESCRIPTION
Now that you only need token to send data to Mixpanel, we can remove all references to API Secret in code samples that send data to Mixpanel. We can also simplify our API Credentials doc.