### PR TITLE
Add localStorage persistence config to web init example

### DIFF
--- a/pages/docs/tracking/javascript-quickstart.mdx
+++ b/pages/docs/tracking/javascript-quickstart.mdx
@@ -40,8 +40,9 @@ You'll need your Project Token for this, which you can get [here](https://mixpan
 //import mixpanel from 'mixpanel-browser';
 
 // Replace YOUR_TOKEN with your Project Token
-// Note: This is configured to track an event for every page view automatically.
-mixpanel.init('YOUR_TOKEN', { debug: true, track_pageview: true });
+// Note: This is configured to track an event for every page view automatically. We also recommend
+//       using localStorage instead of the default cookie for persistence.
+mixpanel.init('YOUR_TOKEN', { debug: true, track_pageview: true, persistence: 'localStorage' });
 
 // Set this to a unique identifier for the user performing the event.
 // eg: their ID in your database or their email address.
@@ -54,8 +55,8 @@ mixpanel.track('Signed Up', {
 })
 ```
 
-🎉 Congratulations, you've tracked your first event! You can see it in Mixpanel via the [Events page](https://mixpanel.com/report/events). For more options, see our [JavaScript reference](/docs/tracking/reference/javascript).        
-        
+🎉 Congratulations, you've tracked your first event! You can see it in Mixpanel via the [Events page](https://mixpanel.com/report/events). For more options, see our [JavaScript reference](/docs/tracking/reference/javascript).
+
 You can also follow our video walkthrough [here](https://www.loom.com/embed/fbba03274dc441b49b578e8a734b1d99).
 
 
@@ -65,7 +66,7 @@ You can also follow our video walkthrough [here](https://www.loom.com/embed/fbba
 Make sure you've disabled ad blockers and your Do Not Track (DNT) browser settings are set to false when testing your JavaScript implementation. If the DNT setting is set to true, then Mixpanel won't collect information from that Mixpanel instance.
 
 We recommend [setting up a proxy server](/docs/tracking/how-tos/tracking-via-proxy#how-to-set-up-a-proxy) so that you don't lose events due to ad-blockers.
-        
+
 ### Does Mixpanel use third-party cookies?
 No, our Mixpanel JavaScript SDK does not set or use any third-party cookies. If you wish to disable cookies entirely, you can set the disable_persistence option to true when initializing your Mixpanel JS instance. Note that disabling persistence will disable the use of super properties and anonymous -> identified user tracking.
 


### PR DESCRIPTION
 Small change to add the recommended persistence option to the JavaScript quickstart example. We state the recommendation in a following section, but I think it'd be good to have this up front in the code example for consistency.