### PR TITLE
Mixpanel/Heliograph branding overrides

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "nextra-theme-docs": "latest",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "sass": "^1.64.0",
         "sharp": "^0.32.3"
       },
       "devDependencies": {
@@ -697,7 +698,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -823,7 +823,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -852,7 +851,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -1020,7 +1018,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -1047,7 +1044,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -1502,7 +1498,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -1548,7 +1543,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -1858,6 +1852,11 @@
         }
       ]
     },
+    "node_modules/immutable": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
+      "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -1919,7 +1918,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -1982,7 +1980,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1991,7 +1988,6 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2012,7 +2008,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3504,7 +3499,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3670,7 +3664,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -3994,7 +3987,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -4238,6 +4230,22 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/sass": {
+      "version": "1.64.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
+      "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.23.0",
@@ -4708,7 +4716,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -5564,7 +5571,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -5632,8 +5638,7 @@
     "binary-extensions": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
-      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
-      "dev": true
+      "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA=="
     },
     "bl": {
       "version": "4.1.0",
@@ -5659,7 +5664,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
       "requires": {
         "fill-range": "^7.0.1"
       }
@@ -5750,7 +5754,6 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
       "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
-      "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5766,7 +5769,6 @@
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
           "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "dev": true,
           "requires": {
             "is-glob": "^4.0.1"
           }
@@ -6109,7 +6111,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
       "requires": {
         "to-regex-range": "^5.0.1"
       }
@@ -6145,7 +6146,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "optional": true
     },
     "function-bind": {
@@ -6367,6 +6367,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "immutable": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.1.tgz",
+      "integrity": "sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A=="
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -6420,7 +6425,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
       "requires": {
         "binary-extensions": "^2.0.0"
       }
@@ -6452,14 +6456,12 @@
     "is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
     },
     "is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -6472,8 +6474,7 @@
     "is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
     },
     "is-obj": {
       "version": "3.0.0",
@@ -7442,8 +7443,7 @@
     "normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-range": {
       "version": "0.1.2",
@@ -7571,8 +7571,7 @@
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "2.3.0",
@@ -7782,7 +7781,6 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
       "requires": {
         "picomatch": "^2.2.1"
       }
@@ -7946,6 +7944,16 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "sass": {
+      "version": "1.64.1",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.64.1.tgz",
+      "integrity": "sha512-16rRACSOFEE8VN7SCgBu1MpYCyN7urj9At898tyzdXFhC+a+yOX5dXwAR7L8/IdPJ1NB8OYoXmD55DM30B2kEQ==",
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
     },
     "scheduler": {
       "version": "0.23.0",
@@ -8282,7 +8290,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
       "requires": {
         "is-number": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "nextra-theme-docs": "latest",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "sharp": "^0.32.3"
+    "sharp": "^0.32.3",
+    "sass": "^1.64.0"
   },
   "devDependencies": {
     "@types/node": "18.11.10",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -1,4 +1,5 @@
-import "./globals.css"
+import "./globals.css";
+import "./overrides.scss";
 import React from 'react';
 import {useEffect} from 'react';
 import { insertGTMScriptTags } from '../components/GTMScripts';

--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -1,0 +1,168 @@
+@use "./theme/colors.scss" as color;
+@use "./theme/typography.scss" as typography;
+
+$base-spacing: 8px;
+
+@font-face {
+    font-display: swap;
+    font-family: typography.$garnett;
+    font-style: normal;
+    font-weight: 500;
+    src: url("#{typography.$cdn-base}#{typography.$garnett-medium-base}.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-display: swap;
+    font-family: typography.$garnett;
+    font-style: normal;
+    font-weight: 400;
+    src: url("#{typography.$cdn-base}#{typography.$garnett-regular-base}.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-display: swap;
+    font-family: typography.$arizona-text-variable;
+    font-style: normal;
+    src: url("#{typography.$cdn-base}#{typography.$arizona-text-base}.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-display: swap;
+    font-family: typography.$arizona-text-light;
+    font-style: normal;
+    src: url("#{typography.$cdn-base}#{typography.$arizona-text-light-base}.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-display: swap;
+    font-family: typography.$apercu;
+    font-weight: 500;
+    src: url("#{typography.$cdn-base}#{typography.$apercu-base}.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-family: typography.$apercu-pro;
+    font-style: normal;
+    font-weight: 400;
+    src: url("#{typography.$cdn-base}/apercu/web/5.008/apercu-regular-pro.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-family: typography.$apercu-pro;
+    font-style: normal;
+    font-weight: 500;
+    src: url("#{typography.$cdn-base}/apercu/web/5.008/apercu-medium-pro.woff2")
+        format("woff2");
+}
+
+@font-face {
+    font-family: typography.$apercu-pro;
+    font-style: normal;
+    font-weight: 700;
+    src: url("#{typography.$cdn-base}/apercu/web/5.008/apercu-bold-pro.woff2")
+        format("woff2");
+}
+
+
+// One-off here because I think the font family definitions this was based on are messed up! 
+@font-face {
+    font-family: "Apercu Monospaced";
+    font-style: normal;
+    font-weight: 400;
+    src: url("https://cdn.mxpnl.com/static/marketing/fonts/apercu/web/5.008/apercu-mono-regular-pro.woff2")
+        format("woff2");
+}
+
+
+
+.theme-mixpanel {
+    line-height: 1.8;
+    font-size: 0.88rem;
+    letter-spacing: 0.3px;
+
+    // We'll handle our own antialiasing.
+    .nx-subpixel-antialiased {
+        -webkit-font-smoothing: unset;
+        -moz-osx-font-smoothing: unset;
+    }
+    
+
+    // We'll handle our own tracking.
+    .nx-tracking-tight {
+        letter-spacing: unset;
+    }
+
+    .nx-font-semibold,
+    p strong {
+        font-weight: 500; // Override to a weight that we actually DO support, otherwise we risk faux bold
+    }
+
+    // Get rid of all heading border-bottoms
+    h1, h2, h3, h4, h5 {
+        &.nx-border-b {
+            border-width: 0;
+        }
+    }
+
+    // Add some space underneath the text underlines
+    .\[text-underline-position\:from-font\] {
+        text-underline-offset: 3px;
+    }
+
+    body {
+        background-color: color.$base100;
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        overscroll-behavior-y: none;
+        font-family: typography.$garnett-stack;
+    }
+
+    // All code/mono type
+    code, kbd, samp, pre {
+        font-family: "Apercu Monospaced", monospace;
+        font-size: 15px;
+        line-height: 150%;
+        font-variant-ligatures: none;
+        font-feature-settings: normal;
+        letter-spacing: initial;
+    }
+
+    .nextra-content {
+        h1, h2, h3, h4, h5 {
+            letter-spacing: -0.3px;
+        }
+    }
+
+    // Right-hand sidebar
+    .nextra-toc {
+        // Remove all hardcoded white backgrounds and shadow filters
+        .nx-shadow-\[0_-12px_16px_white\] {
+            box-shadow: unset;
+        }
+        .nx-bg-white {
+            background-color: unset;
+        }
+
+            // Add some spacing between the sidebar sections
+            ul li {
+                margin-top: $base-spacing * 2;
+                margin-bottom: $base-spacing * 2;
+            }
+
+    }
+
+    .nextra-breadcrumb {
+        text-transform: uppercase;
+        letter-spacing: 2px;
+        font-size: 14px;
+        font-weight: 500;
+    }
+
+}
+

--- a/pages/theme/colors.scss
+++ b/pages/theme/colors.scss
@@ -1,0 +1,44 @@
+@use "sass:color";
+
+// Purple
+$purple200: #1b0b3b;
+$purple140: #5028c0;
+$purple100: #7856ff;
+$purple50: #9075ff;
+$purple40: #b094ff;
+$purple20: #e8ddff;
+
+// Lava
+$lava200: #5b0137;
+$lava140: #cc332b;
+$lava100: #ff7558;
+$lava40: #ffb0a3;
+$lava20: #ffe1d6;
+
+// Mint
+$mint200: #112e29;
+$mint140: #09b096;
+$mint100: #80e1d9;
+$mint40: #bcf0f0;
+$mint20: #e0fafa;
+
+// Mustard
+$mustard200: #a33c16;
+$mustard140: #da6b15;
+$mustard100: #f8bc3b;
+$mustard40: #fede9b;
+$mustard20: #ffefdb;
+
+// Base
+$base120: #eae6e7;
+$base100: #f5f2f2;
+$base80: #fbf9f9;
+
+// Neutrals
+$black: #000;
+$grey100: #201f24;
+$grey80: #626266;
+$grey50: #9b9b9b;
+$grey30: #c0c0c0;
+$grey10: #e9e9e9;
+$white: #fff;

--- a/pages/theme/typography.scss
+++ b/pages/theme/typography.scss
@@ -1,0 +1,23 @@
+// Families
+$garnett: "Garnett";
+$arizona-text-variable: "Arizona Text Variable";
+$arizona-text-light: "Arizona Text Light";
+$apercu: "Apercu Mono";
+$apercu-pro: "Apercu Pro";
+
+// Stacks
+$sans-serif-stack: "Helvetica", "Segoe UI", "Arial", sans-serif;
+$serif-stack: "Book Antiqua", "Palatino", serif;
+$garnett-stack: $garnett, $sans-serif-stack;
+$arizona-text-variable-stack: $arizona-text-variable, $serif-stack;
+$arizona-text-light-stack: $arizona-text-light, $serif-stack;
+$apercu-stack: $apercu, $sans-serif-stack;
+$apercu-pro-stack: $apercu-pro, $sans-serif-stack;
+
+// Paths
+$cdn-base: "https://cdn.mxpnl.com/static/marketing/fonts";
+$garnett-medium-base: "/garnett/garnett-medium";
+$garnett-regular-base: "/garnett/garnett-regular";
+$arizona-text-base: "/arizona-text/arizona-text-variable";
+$arizona-text-light-base: "/arizona-text/arizona-text-light";
+$apercu-base: "/apercu/mono/apercu-mono-bold-pro";

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -11,7 +11,8 @@ function renderComponent<T>(ComponentOrNode: FC<T> | ReactNode, props?: T) {
 const config: DocsThemeConfig = {
   darkMode: false,
   nextThemes: {
-    forcedTheme: `light`,
+    defaultTheme: `theme-mixpanel`,
+    forcedTheme: `theme-mixpanel`
   },
   docsRepositoryBase: "https://github.com/mixpanel/docs/tree/main",
   head: (


### PR DESCRIPTION
What I've done is add a static `mixpanel` theme, which applies an attribute on the root HTML element for us to add style overrides.

This allows us to find the elements/classes we want to override and apply Mixpanel branding to them. I've copied over some of what we're doing on mixpanel.com with theming.

Edit:
Sorry for all the noise & force pushes. This was due to a bug I had with deployments where I had a Node version mismatch (may want to add this to the `engines` field in `package.json` one day).
