### PR TITLE
Fix missing tab around Android example section

### DIFF
--- a/pages/docs/tracking/how-tos/privacy-friendly-tracking.mdx
+++ b/pages/docs/tracking/how-tos/privacy-friendly-tracking.mdx
@@ -78,9 +78,11 @@ useIPAddressForGeoLocation = NO
 Mixpanel.initialize(token: "MIXPANEL_TOKEN", useIPAddressForGeoLocation: false)
 ```
 </Tab>
+<Tab>
   ```xml Android
 <meta-data android:name="com.mixpanel.android.MPConfig.UseIpAddressForGeolocation" android:value="false" />
 ```
+</Tab>
 </Tabs>
 
 ## Anonymizing Users


### PR DESCRIPTION
Android code example section is not in a <Tab></Tab> tag and it is always visible, regardless of tab selection.