### PR TITLE
Add, Customize UI for Algolia search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 .next
 node_modules
+.vercel
+.env*.local

--- a/components/Search/Search.tsx
+++ b/components/Search/Search.tsx
@@ -1,0 +1,15 @@
+
+import { DocSearch } from '@docsearch/react';
+import '@docsearch/css';
+
+export default function Search() {
+
+
+    return (
+        <DocSearch
+            appId="MQIQQRKVX5"
+            indexName="mixpanel_Docs v2"
+            apiKey="d6267db26ac89477a9a87ea82da493b7"
+            insights={true} />
+        )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
+        "@docsearch/js": "^3.5.1",
+        "@docsearch/react": "^3.5.1",
         "clsx": "^1.2.1",
         "next": "^13.0.6",
         "nextra": "latest",
@@ -24,6 +26,162 @@
         "postcss": "^8.4.21",
         "tailwindcss": "^3.3.1",
         "typescript": "^4.9.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/cache-browser-local-storage": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.19.1.tgz",
+      "integrity": "sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==",
+      "dependencies": {
+        "@algolia/cache-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/cache-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.19.1.tgz",
+      "integrity": "sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg=="
+    },
+    "node_modules/@algolia/cache-in-memory": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.19.1.tgz",
+      "integrity": "sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==",
+      "dependencies": {
+        "@algolia/cache-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-account": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.19.1.tgz",
+      "integrity": "sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==",
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.19.1.tgz",
+      "integrity": "sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==",
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.19.1.tgz",
+      "integrity": "sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.19.1.tgz",
+      "integrity": "sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==",
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.19.1.tgz",
+      "integrity": "sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==",
+      "dependencies": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/logger-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.19.1.tgz",
+      "integrity": "sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw=="
+    },
+    "node_modules/@algolia/logger-console": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.19.1.tgz",
+      "integrity": "sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==",
+      "dependencies": {
+        "@algolia/logger-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.19.1.tgz",
+      "integrity": "sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==",
+      "dependencies": {
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/requester-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.19.1.tgz",
+      "integrity": "sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ=="
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.19.1.tgz",
+      "integrity": "sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==",
+      "dependencies": {
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "node_modules/@algolia/transporter": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.19.1.tgz",
+      "integrity": "sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==",
+      "dependencies": {
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -47,6 +205,47 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.1.tgz",
+      "integrity": "sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA=="
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.1.tgz",
+      "integrity": "sha512-EXi8de5njxgP6TV3N9ytnGRLG9zmBNTEZjR4VzwPcpPLbZxxTLG2gaFyJyKiFVQxHW/DPlMrDJA3qoRRGEkgZw==",
+      "dependencies": {
+        "@docsearch/react": "3.5.1",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.1.tgz",
+      "integrity": "sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.1",
+        "algoliasearch": "^4.0.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/@headlessui/react": {
@@ -657,6 +856,27 @@
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
+      "integrity": "sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.19.1",
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/cache-in-memory": "4.19.1",
+        "@algolia/client-account": "4.19.1",
+        "@algolia/client-analytics": "4.19.1",
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-personalization": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/logger-console": "4.19.1",
+        "@algolia/requester-browser-xhr": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/requester-node-http": "4.19.1",
+        "@algolia/transporter": "4.19.1"
       }
     },
     "node_modules/ansi-sequence-parser": {
@@ -3820,6 +4040,15 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "node_modules/preact": {
+      "version": "10.16.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -4261,6 +4490,15 @@
       "integrity": "sha512-t44QCeDKAPf1mtQH3fYpWz8IM/DyvHLjs8wUvvwMYxk5moOqCzrMSxK6HQVD0QVmVjXFavoFIPRVrMuJPKAvtg==",
       "dependencies": {
         "compute-scroll-into-view": "^3.0.2"
+      }
+    },
+    "node_modules/search-insights": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.7.0.tgz",
+      "integrity": "sha512-GLbVaGgzYEKMvuJbHRhLi1qoBFnjXZGZ6l4LxOYPCp4lI2jDRB3jPU9/XNhMwv6kvnA9slTreq6pvK+b3o3aqg==",
+      "peer": true,
+      "engines": {
+        "node": ">=8.16.0"
       }
     },
     "node_modules/section-matter": {
@@ -5142,6 +5380,152 @@
     }
   },
   "dependencies": {
+    "@algolia/autocomplete-core": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.9.3.tgz",
+      "integrity": "sha512-009HdfugtGCdC4JdXUbVJClA0q0zh24yyePn+KUGk3rP7j8FEe/m5Yo/z65gn6nP/cM39PxpzqKrL7A6fP6PPw==",
+      "requires": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.9.3",
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.9.3.tgz",
+      "integrity": "sha512-a/yTUkcO/Vyy+JffmAnTWbr4/90cLzw+CC3bRbhnULr/EM0fGNvM13oQQ14f2moLMcVDyAx/leczLlAOovhSZg==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "@algolia/autocomplete-preset-algolia": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.9.3.tgz",
+      "integrity": "sha512-d4qlt6YmrLMYy95n5TB52wtNDr6EgAIPH81dvvvW8UmuWRgxEtY0NJiPwl/h95JtG2vmRM804M0DSwMCNZlzRA==",
+      "requires": {
+        "@algolia/autocomplete-shared": "1.9.3"
+      }
+    },
+    "@algolia/autocomplete-shared": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.9.3.tgz",
+      "integrity": "sha512-Wnm9E4Ye6Rl6sTTqjoymD+l8DjSTHsHboVRYrKgEt8Q7UHm9nYbqhN/i0fhUYA3OAEH7WA8x3jfpnmJm3rKvaQ==",
+      "requires": {}
+    },
+    "@algolia/cache-browser-local-storage": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.19.1.tgz",
+      "integrity": "sha512-FYAZWcGsFTTaSAwj9Std8UML3Bu8dyWDncM7Ls8g+58UOe4XYdlgzXWbrIgjaguP63pCCbMoExKr61B+ztK3tw==",
+      "requires": {
+        "@algolia/cache-common": "4.19.1"
+      }
+    },
+    "@algolia/cache-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.19.1.tgz",
+      "integrity": "sha512-XGghi3l0qA38HiqdoUY+wvGyBsGvKZ6U3vTiMBT4hArhP3fOGLXpIINgMiiGjTe4FVlTa5a/7Zf2bwlIHfRqqg=="
+    },
+    "@algolia/cache-in-memory": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.19.1.tgz",
+      "integrity": "sha512-+PDWL+XALGvIginigzu8oU6eWw+o76Z8zHbBovWYcrtWOEtinbl7a7UTt3x3lthv+wNuFr/YD1Gf+B+A9V8n5w==",
+      "requires": {
+        "@algolia/cache-common": "4.19.1"
+      }
+    },
+    "@algolia/client-account": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.19.1.tgz",
+      "integrity": "sha512-Oy0ritA2k7AMxQ2JwNpfaEcgXEDgeyKu0V7E7xt/ZJRdXfEpZcwp9TOg4TJHC7Ia62gIeT2Y/ynzsxccPw92GA==",
+      "requires": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "@algolia/client-analytics": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.19.1.tgz",
+      "integrity": "sha512-5QCq2zmgdZLIQhHqwl55ZvKVpLM3DNWjFI4T+bHr3rGu23ew2bLO4YtyxaZeChmDb85jUdPDouDlCumGfk6wOg==",
+      "requires": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "@algolia/client-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.19.1.tgz",
+      "integrity": "sha512-3kAIVqTcPrjfS389KQvKzliC559x+BDRxtWamVJt8IVp7LGnjq+aVAXg4Xogkur1MUrScTZ59/AaUd5EdpyXgA==",
+      "requires": {
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "@algolia/client-personalization": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.19.1.tgz",
+      "integrity": "sha512-8CWz4/H5FA+krm9HMw2HUQenizC/DxUtsI5oYC0Jxxyce1vsr8cb1aEiSJArQT6IzMynrERif1RVWLac1m36xw==",
+      "requires": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "@algolia/client-search": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.19.1.tgz",
+      "integrity": "sha512-mBecfMFS4N+yK/p0ZbK53vrZbL6OtWMk8YmnOv1i0LXx4pelY8TFhqKoTit3NPVPwoSNN0vdSN9dTu1xr1XOVw==",
+      "requires": {
+        "@algolia/client-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
+    },
+    "@algolia/logger-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.19.1.tgz",
+      "integrity": "sha512-i6pLPZW/+/YXKis8gpmSiNk1lOmYCmRI6+x6d2Qk1OdfvX051nRVdalRbEcVTpSQX6FQAoyeaui0cUfLYW5Elw=="
+    },
+    "@algolia/logger-console": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.19.1.tgz",
+      "integrity": "sha512-jj72k9GKb9W0c7TyC3cuZtTr0CngLBLmc8trzZlXdfvQiigpUdvTi1KoWIb2ZMcRBG7Tl8hSb81zEY3zI2RlXg==",
+      "requires": {
+        "@algolia/logger-common": "4.19.1"
+      }
+    },
+    "@algolia/requester-browser-xhr": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.19.1.tgz",
+      "integrity": "sha512-09K/+t7lptsweRTueHnSnmPqIxbHMowejAkn9XIcJMLdseS3zl8ObnS5GWea86mu3vy4+8H+ZBKkUN82Zsq/zg==",
+      "requires": {
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "@algolia/requester-common": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.19.1.tgz",
+      "integrity": "sha512-BisRkcWVxrDzF1YPhAckmi2CFYK+jdMT60q10d7z3PX+w6fPPukxHRnZwooiTUrzFe50UBmLItGizWHP5bDzVQ=="
+    },
+    "@algolia/requester-node-http": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.19.1.tgz",
+      "integrity": "sha512-6DK52DHviBHTG2BK/Vv2GIlEw7i+vxm7ypZW0Z7vybGCNDeWzADx+/TmxjkES2h15+FZOqVf/Ja677gePsVItA==",
+      "requires": {
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
+    "@algolia/transporter": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.19.1.tgz",
+      "integrity": "sha512-nkpvPWbpuzxo1flEYqNIbGz7xhfhGOKGAZS7tzC+TELgEmi7z99qRyTfNSUlW7LZmB3ACdnqAo+9A9KFBENviQ==",
+      "requires": {
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/requester-common": "4.19.1"
+      }
+    },
     "@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -5154,6 +5538,31 @@
       "integrity": "sha512-8jI69toZqqcsnqGGqwGS4Qb1VwLOEp4hz+CXPywcvjs60u3B4Pom/U/7rm4W8tMOYEB+E9wgD0mW1l3r8qlI9Q==",
       "requires": {
         "regenerator-runtime": "^0.13.11"
+      }
+    },
+    "@docsearch/css": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.1.tgz",
+      "integrity": "sha512-2Pu9HDg/uP/IT10rbQ+4OrTQuxIWdKVUEdcw9/w7kZJv9NeHS6skJx1xuRiFyoGKwAzcHXnLp7csE99sj+O1YA=="
+    },
+    "@docsearch/js": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.5.1.tgz",
+      "integrity": "sha512-EXi8de5njxgP6TV3N9ytnGRLG9zmBNTEZjR4VzwPcpPLbZxxTLG2gaFyJyKiFVQxHW/DPlMrDJA3qoRRGEkgZw==",
+      "requires": {
+        "@docsearch/react": "3.5.1",
+        "preact": "^10.0.0"
+      }
+    },
+    "@docsearch/react": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.5.1.tgz",
+      "integrity": "sha512-t5mEODdLzZq4PTFAm/dvqcvZFdPDMdfPE5rJS5SC8OUq9mPzxEy6b+9THIqNM9P0ocCb4UC5jqBrxKclnuIbzQ==",
+      "requires": {
+        "@algolia/autocomplete-core": "1.9.3",
+        "@algolia/autocomplete-preset-algolia": "1.9.3",
+        "@docsearch/css": "3.5.1",
+        "algoliasearch": "^4.0.0"
       }
     },
     "@headlessui/react": {
@@ -5532,6 +5941,27 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
       "requires": {}
+    },
+    "algoliasearch": {
+      "version": "4.19.1",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.19.1.tgz",
+      "integrity": "sha512-IJF5b93b2MgAzcE/tuzW0yOPnuUyRgGAtaPv5UUywXM8kzqfdwZTO4sPJBzoGz1eOy6H9uEchsJsBFTELZSu+g==",
+      "requires": {
+        "@algolia/cache-browser-local-storage": "4.19.1",
+        "@algolia/cache-common": "4.19.1",
+        "@algolia/cache-in-memory": "4.19.1",
+        "@algolia/client-account": "4.19.1",
+        "@algolia/client-analytics": "4.19.1",
+        "@algolia/client-common": "4.19.1",
+        "@algolia/client-personalization": "4.19.1",
+        "@algolia/client-search": "4.19.1",
+        "@algolia/logger-common": "4.19.1",
+        "@algolia/logger-console": "4.19.1",
+        "@algolia/requester-browser-xhr": "4.19.1",
+        "@algolia/requester-common": "4.19.1",
+        "@algolia/requester-node-http": "4.19.1",
+        "@algolia/transporter": "4.19.1"
+      }
     },
     "ansi-sequence-parser": {
       "version": "1.1.0",
@@ -7651,6 +8081,11 @@
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
       "dev": true
     },
+    "preact": {
+      "version": "10.16.0",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.16.0.tgz",
+      "integrity": "sha512-XTSj3dJ4roKIC93pald6rWuB2qQJO9gO2iLLyTe87MrjQN+HklueLsmskbywEWqCHlclgz3/M4YLL2iBr9UmMA=="
+    },
     "prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -7970,6 +8405,12 @@
       "requires": {
         "compute-scroll-into-view": "^3.0.2"
       }
+    },
+    "search-insights": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.7.0.tgz",
+      "integrity": "sha512-GLbVaGgzYEKMvuJbHRhLi1qoBFnjXZGZ6l4LxOYPCp4lI2jDRB3jPU9/XNhMwv6kvnA9slTreq6pvK+b3o3aqg==",
+      "peer": true
     },
     "section-matter": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
   },
   "homepage": "https://github.com/mixpanel/docs#readme",
   "dependencies": {
+    "@docsearch/js": "^3.5.1",
+    "@docsearch/react": "^3.5.1",
     "clsx": "^1.2.1",
     "next": "^13.0.6",
     "nextra": "latest",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -3,13 +3,16 @@ import "./overrides.scss";
 import React from 'react';
 import {useEffect} from 'react';
 import { insertGTMScriptTags } from '../components/GTMScripts';
+import type { AppProps } from 'next/app'
 
 
-export default function MyApp({ Component, pageProps }) {
+export default function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
         insertGTMScriptTags();
+        // @ts-ignore
         if (typeof Sprig !== `undefined`) {
           // if Sprig loaded in browser
+          // @ts-ignore
           Sprig('track', 'helpDocViewed')
         }
     }, []);

--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -2,6 +2,9 @@
 @use "./theme/typography.scss" as typography;
 
 $base-spacing: 8px;
+$border-radius: 8px;
+$border-radius-md: 24px;
+$border-radius-lg: 100px;
 
 @font-face {
     font-display: swap;
@@ -162,6 +165,115 @@ $base-spacing: 8px;
         letter-spacing: 2px;
         font-size: 14px;
         font-weight: 500;
+    }
+
+    // Custom Search theming from Algolia Docsearch
+    .DocSearch {
+        --docsearch-primary-color: #{color.$purple200};
+        --docsearch-highlight-color:  #{color.$purple100};
+        --docsearch-spacing: #{$base-spacing * 3};
+        --docsearch-modal-width: 47rem;
+        --docsearch-container-background: rgba(27,11,59,.85);
+        --docsearch-modal-background: white;
+        --docsearch-footer-height: 60px;
+        --docsearch-hit-color: #{color.$purple200};
+        --docsearch-muted-color: #{color.$purple200};
+        
+        // Global Nextra theming makes the focus ring look a little nasty
+        input:focus-visible {
+            box-shadow: none;
+        }
+
+        &-SearchBar {
+            padding: 80px 88px 32px;
+        }
+
+        &-Modal {
+            border-radius: $border-radius-md;
+        }
+
+        &-Dropdown {
+            padding: 0 90px;
+            margin-bottom: 20px;
+        }
+        
+        .DocSearch-Hit-action, .DocSearch-Hit-icon, .DocSearch-Hit-Tree {
+            color: #b094ff;
+        }
+
+        &-Hit-Tree {
+            opacity: 1;
+        }
+
+        &-Hit a {
+            transition: background-color 0.1s linear;
+            border-radius: 0;
+            box-shadow: none;
+        }
+
+        &-Hits mark {
+            color: color.$purple100;
+            font-weight: bold;
+        }
+
+        &-Hit {
+            border-radius: $border-radius;
+            padding-bottom: initial;
+            margin-bottom: $base-spacing;
+            border: 2px solid #{color.$purple100};
+            overflow: hidden;
+        }
+
+        &-Form {
+            border-radius: $border-radius-md;
+            box-shadow: inset 0 0 0 2px color.$grey30;
+            transition: box-shadow 0.15s linear;
+
+            .DocSearch-MagnifierLabel {
+                color: color.$grey30;
+                transition: color 0.15s linear;
+            }
+
+            &:focus-within {
+                box-shadow: var(--docsearch-searchbox-shadow);
+
+                .DocSearch-MagnifierLabel {
+                    color: var(--docsearch-highlight-color);
+                }
+            }
+        }
+
+        &-Footer {
+            border-radius: 0 0 $border-radius-md $border-radius-md;
+        }
+
+        &-Commands-Key {
+            box-shadow: none;
+            background: transparent;
+            color: color.$grey50;
+        }
+
+        &-Label {
+            color: color.$grey50;
+        }
+
+        &-Screen-Icon {
+            display: flex;
+            justify-content: center;
+            color: unset;
+        }
+
+        &-NoResults-Prefill-List {
+            display: none;
+        }
+
+        &-StartScreen {
+            display: none;
+        }
+
+        &-NoResults {
+            color: color.$grey50;
+        }
     }
 
 }

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -1,5 +1,6 @@
 import { FC, ReactNode } from "react";
 import { DocsThemeConfig } from "nextra-theme-docs";
+import Search from './components/Search/Search';
 import MixpanelLogoWordmark from "./components/svg/MixpanelLogoWordmark";
 
 function renderComponent<T>(ComponentOrNode: FC<T> | ReactNode, props?: T) {
@@ -43,6 +44,9 @@ const config: DocsThemeConfig = {
   useNextSeoProps: () => ({
     titleTemplate: '%s - Mixpanel Docs'
   }),
+  search: {
+    component: Search
+  },
   project: {
     link: "https://github.com/mixpanel/docs",
   },


### PR DESCRIPTION
Taking the original, non-themed version of Algolia's docsearch plugin:
![image](https://github.com/mixpanel/docs/assets/1228559/b04fced4-571e-4971-a7f6-7b7e80bde43e)


I've looked at where modals like these have been themed across Heliograph, our design system (especially on Pricing). Take a look for yourself, but here's a preview:
<img width="1205" alt="image" src="https://github.com/mixpanel/docs/assets/1228559/e260cadc-a88b-4f51-a759-18c59ad09e2b">
