### PR TITLE
Fix overlap issue with background on shorter viewports

### DIFF
--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -146,7 +146,7 @@ $base-spacing: 8px;
             box-shadow: unset;
         }
         .nx-bg-white {
-            background-color: unset;
+            background-color: color.$base100;
         }
 
             // Add some spacing between the sidebar sections


### PR DESCRIPTION
Resolves [this issue Mikey noticed back in Slack](https://mixpanel.slack.com/archives/C050U6CQRLZ/p1691089379243529?thread_ts=1691081393.202829&cid=C050U6CQRLZ).

![image](https://github.com/mixpanel/docs/assets/1228559/6d349ce7-0cc8-4272-8f70-426de795883c)

Example page: https://docs.mixpanel.com/docs/tracking/how-tos/user-profiles
