### PR TITLE
Update changelog-2023-08-02-empty-states.mdx

### DIFF
--- a/pages/changelogs/changelog-2023-08-02-empty-states.mdx
+++ b/pages/changelogs/changelog-2023-08-02-empty-states.mdx
@@ -1,5 +1,11 @@
-# Introducing a new design for dashboards without data
-
+---
+title: "Troubleshoot better with a new design for Boards without data"
+slug: "changelog-2023-08-02-empty-states"
+hidden: false
+createdAt: "2023-08-02T17:39:02.165Z"
+updatedAt: "2023-08-02T17:39:02.165Z"
+date: "2023-08-02"
+---
 We’re excited to announce that we have released a new design for Boards without data. Now when a report can’t populate, it will display one of two states: a faded out sample report or a “no data” status. 
 
 ![changelog Image](/changelog/empty-states-screenshot.png)


### PR DESCRIPTION
I tried to fix this page by giving the right metadata, right now it's showing up at the bottom of our changelog all weird

I also changed the title because we just said "introducing warehouse connectors" so it'd have 2 posts back to back about "introducing", which is confusing since warehouse connectors is very different than empty states