### PR TITLE
Update 2023-08-10-warehouse-connectors.mdx

### DIFF
--- a/pages/changelogs/2023-08-10-warehouse-connectors.mdx
+++ b/pages/changelogs/2023-08-10-warehouse-connectors.mdx
@@ -34,4 +34,4 @@ This lets you answer questions like:
 - Which campaigns account for the most revenue? What is the breakdown of the ARR of customers that use this feature?
 - What is our average time to resolve a ticket?
 
-Navigate to Project Settings > Warehouse Sources to get started today. For more information, check out our docs on setting up via [BigQuery](https://docs.mixpanel.com/docs/tracking/integrations/bigquery) and [Snowflake](https://docs.mixpanel.com/docs/tracking/integrations/snowflake).
+Navigate to Project Settings > Warehouse Sources to get started today. For more information, check out our docs on setting up via [BigQuery](https://docs.mixpanel.com/docs/tracking/data-warehouse/bigquery) and [Snowflake](https://docs.mixpanel.com/docs/tracking/data-warehouse/snowflake).


### PR DESCRIPTION
Update broken link for BigQuery + Snowflake

Currently points to https://docs.mixpanel.com/docs/tracking/integrations/bigquery  and https://docs.mixpanel.com/docs/tracking/data-warehouse/snowflake which leads to a 404 page. 

Correct link should be https://docs.mixpanel.com/docs/tracking/data-warehouse/bigquery and https://docs.mixpanel.com/docs/tracking/data-warehouse/snowflake