### PR TITLE
Update 2023-08-29-boards-on-boards.mdx

### DIFF
--- a/pages/changelogs/2023-08-29-boards-on-boards.mdx
+++ b/pages/changelogs/2023-08-29-boards-on-boards.mdx
@@ -6,7 +6,13 @@ createdAt: "2023-08-29T14:59:02.165Z"
 updatedAt: "2023-08-29T14:59:02.165Z"
 date: "2023-08-29"
 ---
-![changelog Image](/changelog/Boards_on_Boards.gif)
+<div style="position: relative; padding-bottom: 58.1270182992465%; height: 0;">
+  <iframe src="https://www.loom.com/embed/6e8e3c53675b4057aa472d8f5dbbf6dd?sid=24883291-413a-4c57-ac03-515d3d33e8b0"
+    frameborder="0" 
+    webkitallowfullscreen mozallowfullscreen allowfullscreen 
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;">
+  </iframe>
+</div>
 
 You can now nest Boards within other Boards for more flexible, contextual organization of your analyses. 
 


### PR DESCRIPTION
replaced the Boards on Boards GIF with Loom. If the Loom doesn't work please just delete the Boards on Boards image anyways.