### PR TITLE
Update export.openapi.yaml

### DIFF
--- a/openapi/src/export.openapi.yaml
+++ b/openapi/src/export.openapi.yaml
@@ -63,8 +63,7 @@ paths:
       responses:
         "200":
           description: >-
-            Success. The return is format is one event per line sorted by
-            increasing timestamp. Each line is a valid JSON object, but the full
+            Success. Each line is a valid JSON object, but the full
             return itself is JSONL.
 
           content:


### PR DESCRIPTION
Removing "The return is format is one event per line sorted by increasing timestamp." for Raw Export API.  There currently isn't sorting with Export API (see SRFE-4689).