### PR TITLE
Update user-profiles.md

### DIFF
--- a/pages/docs/tracking/how-tos/user-profiles.md
+++ b/pages/docs/tracking/how-tos/user-profiles.md
@@ -91,7 +91,7 @@ We recommend using the `$name` and `$email` properties if you're uploading a use
 When editing the CSV that you want to upload as profiles, you should **not** include column headers (e.g., Email, Name, etc.). Instead, you’ll identify column headers during the CSV upload wizard in the Mixpanel UI.
 
 **Note**:
-- If you import user profiles using $distinct_id values that already exist, those profiles will be updated with the additional user profile properties. On the other hand, if you upload user profiles that have the same email address or the same name as existing user profiles but a different $distinct_id, you will be uploading duplicates - they will not be combined.
+- If you import user profiles using \$distinct_id values that already exist, those profiles will be updated with the additional user profile properties. On the other hand, if you upload user profiles that have the same email address or the same name as existing user profiles but a different \$distinct_id, you will be uploading duplicates - they will not be combined.
 - If you upload a CSV with new information for existing properties on existing users, the existing property values will be overwritten. If the new information is for new properties on existing users, it will be added as an additional property for the user. 
 - The maximum size for your CSV is 1M rows.
 


### PR DESCRIPTION
Some text is inadvertently being rendered as LaTeX formulas due to the integration used elsewhere in the documentation. See screenshot for an example of the bug in question.

The $ needs to be escaped for it not to mark the beginning of a LaTeX formula.

<img width="1059" alt="Screen Shot 2023-09-13 at 2 18 06 PM" src="https://github.com/mixpanel/docs/assets/100325393/21818fa7-0635-4968-a621-cf90b144fbb7">