### PR TITLE
Update query.openapi.yaml

### DIFF
--- a/openapi/src/query.openapi.yaml
+++ b/openapi/src/query.openapi.yaml
@@ -1668,6 +1668,11 @@ paths:
 
         * You cannot make remote network requests (using XMLHttpRequest) from
         JavaScript.
+
+        **Rate limit**
+
+        Queries to the JQL endpoint contribute to Query API rate limit and have their own individual limit as well. There is a maximum of 5 concurrent queries and of 60 queries per hour. There is also a 5 GB limit on data that can be processed in a single query, and a 2 GB limit on the resulting output data.
+      
       parameters:
         - $ref: ./common/parameters.yaml#/query/projectId
         - $ref: '#/components/parameters/workspaceId'


### PR DESCRIPTION
Add rate limit to JQL documentation