### PR TITLE
Add url param to focus on tab in mobile

### DIFF
--- a/components/ExtendedTabs/ExtendedTabs.tsx
+++ b/components/ExtendedTabs/ExtendedTabs.tsx
@@ -1,0 +1,31 @@
+import { Tabs } from 'nextra-theme-docs'
+import { useEffect, useState } from 'react';
+
+type ExtendedTabsType = {
+    children: JSX.Element;
+    urlParam: string;
+    urlToItemsMap: Record<string, string>;
+}
+
+export default function ExtendedTabs(props: ExtendedTabsType) {
+    const [selectedIndex, setSelectedIndex] = useState(0);
+
+    useEffect(() => {
+        const queryString = window.location.search;
+        const urlParams = new URLSearchParams(queryString);
+        const item = urlParams.get(props.urlParam);
+        if (item && item in props.urlToItemsMap) {
+            const index = Object.keys(props.urlToItemsMap).indexOf(item);
+            setSelectedIndex(index);
+        }
+    })
+
+    return (
+        <Tabs
+            items={Object.values(props.urlToItemsMap)}
+            selectedIndex={selectedIndex}
+        >
+            {props.children}
+        </Tabs>
+    )
+}

--- a/pages/docs/tracking/mobile.mdx
+++ b/pages/docs/tracking/mobile.mdx
@@ -1,9 +1,13 @@
 # Mobile
 
-import { Tab, Tabs } from 'nextra-theme-docs'
+import { Tab, Tabs } from 'nextra-theme-docs';
+
+import ExtendedTabs from '../../../components/ExtendedTabs/ExtendedTabs';
+import { urlToItemsMap } from '../../../utils/mobileUrlParams';
+
 
 ## Step 1: Install the SDK
-<Tabs items={['React Native', 'Flutter', 'iOS (Objective-C)', 'iOS (Swift)', 'Android', 'Unity']}>
+<ExtendedTabs urlParam="sdk" urlToItemsMap={urlToItemsMap}>
 
 <Tab>
 Under your app's root directory, run:
@@ -76,12 +80,12 @@ Add `https://github.com/mixpanel/mixpanel-unity.git#master` to the dependencies 
 
 Alternatively, you can download and install the .unitypackage file from our [releases page](https://github.com/mixpanel/mixpanel-unity/releases).
 </Tab>
-</Tabs>
+</ExtendedTabs>
 
 ## Step 2: Track your first event
 You'll need your Project Token for this, which you can get [here](https://mixpanel.com/settings/project).
 
-<Tabs items={['React Native', 'Flutter', 'iOS (Objective-C)', 'iOS (Swift)', 'Android', 'Unity']}>
+<ExtendedTabs urlParam="sdk" urlToItemsMap={urlToItemsMap}>
 
 <Tab>
 ```javascript
@@ -195,7 +199,7 @@ props["Signup Type"] =  "Referral";
 Mixpanel.Track('Signup', props);
 ```
 </Tab>
-</Tabs>
+</ExtendedTabs>
 
 🎉 Congratulations, you've tracked your first event! You can see it in Mixpanel via the [Events](https://mixpanel.com/report/events) page.
 

--- a/utils/mobileUrlParams.ts
+++ b/utils/mobileUrlParams.ts
@@ -1,0 +1,8 @@
+export const urlToItemsMap = {
+    'reactnative': `React Native`,
+    'flutter': `Flutter`,
+    'ios': `iOS (Objective-C)`,
+    'swift': `iOS (Swift)`,
+    'android': `Android`,
+    'unity': `Unity`,
+}


### PR DESCRIPTION
When you go to something like https://docs-git-tiffany-tab-mixpanel.vercel.app/docs/tracking/mobile?sdk=ios , it should have both tabs on the page focus on objective c