### PR TITLE
Openapi staging flow

### DIFF
--- a/.github/workflows/rdme-openapi.yml
+++ b/.github/workflows/rdme-openapi.yml
@@ -17,3 +17,4 @@ jobs:
     - run: npm run api:publish
       env:
         README_API_KEY: ${{ secrets.README_API_KEY }}
+        README_VERSION: '3.26'

--- a/.github/workflows/rdme-staging.yml
+++ b/.github/workflows/rdme-staging.yml
@@ -1,9 +1,10 @@
 name: Generate ReadMe Staging 🦉
 
 on:
-  # run this workflow on all PRs that have reference/ changed
+  # run this workflow on all PRs that have reference dirs changed
   pull_request:
     paths:
+      - 'openapi/**'
       - 'reference/**'
       - '.github/actions/**'
       - '.github/workflows/rdme-staging.yml'
@@ -40,6 +41,13 @@ jobs:
         uses: readmeio/rdme@v8
         with:
           rdme: docs ./reference --key=${{ secrets.README_API_KEY }} --version=0.0-pr-${{ github.event.number }}
+
+      # Push openapi specs to staging env
+      - run: npm run api:build
+      - run: npm run api:publish
+        env:
+          README_API_KEY: ${{ secrets.README_API_KEY }}
+          README_VERSION: 0.0-pr-${{ github.event.number }}
 
   # build and update comment with the proper link
   preview-notify:

--- a/openapi/publish.js
+++ b/openapi/publish.js
@@ -1,21 +1,21 @@
+const fs = require("fs");
+const path = require("path");
 const process = require("node:process");
 const util = require("node:util");
+const YAML = require("yaml");
+
 const exec = util.promisify(require("node:child_process").exec);
 
 const README_API_KEY = process.env.README_API_KEY;
-
-// map OAS files to readme.com API Definition IDs
-const API_DEFS = {
-  annotations: `6494a86ab6a2c4001dd7e9a3`,
-  connectors: `6494a86ab6a2c4001dd7e99e`,
-  "data-pipelines": `6494a86ab6a2c4001dd7e99b`,
-  export: `6494a86ab6a2c4001dd7e9a0`,
-  identity: `6494a86ab6a2c4001dd7e9a1`,
-  ingestion: `6494a86ab6a2c4001dd7e99d`,
-  "lexicon-schemas": `6494a86ab6a2c4001dd7e99c`,
-  query: `6494a86ab6a2c4001dd7e99f`,
-  "service-accounts": `6494a86ab6a2c4001dd7e9a2`,
-};
+if (!README_API_KEY) {
+  console.error(`README_API_KEY not set`);
+  process.exit(1);
+}
+const README_VERSION = process.env.README_VERSION;
+if (!README_VERSION) {
+  console.error(`README_VERSION not set`);
+  process.exit(1);
+}
 
 async function execAndLog(cmd) {
   try {
@@ -28,11 +28,46 @@ async function execAndLog(cmd) {
   }
 }
 
-async function validateAndPublish(fn, id) {
-  await execAndLog(`npx rdme openapi:validate ${fn}`);
-  await execAndLog(`npx rdme openapi ${fn} --id=${id} --key=${README_API_KEY}`);
+async function updateSpecs() {
+  // fetch IDs of openapi specs via readme API
+  const res = await fetch(
+    `https://dash.readme.com/api/v1/api-specification?perPage=10&page=1`,
+    {
+      headers: {
+        Authorization: `Basic ${Buffer.from(README_API_KEY).toString(
+          "base64"
+        )}`,
+        "x-readme-version": README_VERSION,
+      },
+    }
+  );
+  const remoteSpecMetas = await res.json();
+
+  // get all openapi specs from out/ folder
+  const outBase = path.resolve(__dirname, `out`);
+  const filenames = fs
+    .readdirSync(outBase)
+    .filter((fn) => fn.endsWith(`.openapi.yaml`));
+
+  for (specFile of filenames) {
+    // get ID of each spec by matching title between filename and metadata
+    const fullPath = path.join(outBase, specFile);
+    const yamlStr = fs.readFileSync(fullPath, "utf8");
+    const spec = YAML.parse(yamlStr);
+    const specMeta = remoteSpecMetas.find((m) => m.title === spec.info.title);
+    if (!specMeta) {
+      console.log(`!!! No spec found for "${spec.info.title}"`);
+      continue;
+    }
+    const specId = specMeta.id;
+
+    // validate and publish spec
+    console.log(`Updating ${spec.info.title} (${specFile}, ID ${specId})`);
+    await execAndLog(`npx rdme openapi:validate ${fullPath}`);
+    await execAndLog(
+      `npx rdme openapi ${fullPath} --id=${specId} --key=${README_API_KEY}`
+    );
+  }
 }
 
-for (const [def, id] of Object.entries(API_DEFS)) {
-  validateAndPublish(`openapi/out/${def}.openapi.yaml`, id);
-}
+updateSpecs();

--- a/openapi/src/query.openapi.yaml
+++ b/openapi/src/query.openapi.yaml
@@ -49,7 +49,7 @@ paths:
       summary: Query Saved Report
       tags:
         - Insights
-      description: Get data from your Insights reports.
+      description: Get data from your Insights reports all the time, right now every time.
       parameters:
         - $ref: ./common/parameters.yaml#/query/projectId
         - $ref: '#/components/parameters/workspaceId'

--- a/openapi/src/query.openapi.yaml
+++ b/openapi/src/query.openapi.yaml
@@ -49,7 +49,7 @@ paths:
       summary: Query Saved Report
       tags:
         - Insights
-      description: Get data from your Insights reports all the time, right now every time.
+      description: Get data from your Insights reports.
       parameters:
         - $ref: ./common/parameters.yaml#/query/projectId
         - $ref: '#/components/parameters/workspaceId'

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "postcss": "^8.4.31",
         "rdme": "8.6.6",
         "tailwindcss": "^3.3.1",
-        "typescript": "^4.9.3"
+        "typescript": "^4.9.3",
+        "yaml": "^2.3.3"
       }
     },
     "node_modules/@75lb/deep-merge": {
@@ -8673,9 +8674,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true,
       "engines": {
         "node": ">= 14"
@@ -14943,9 +14944,9 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-      "integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.3.tgz",
+      "integrity": "sha512-zw0VAJxgeZ6+++/su5AFoqBbZbrEakwu+X0M5HmcwUiBL7AzcuPKjj5we4xfQLp78LkEMpD0cOnUhmgOVy3KdQ==",
       "dev": true
     },
     "yaml-ast-parser": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "postcss": "^8.4.31",
     "rdme": "8.6.6",
     "tailwindcss": "^3.3.1",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.3",
+    "yaml": "2.3.3"
   }
 }


### PR DESCRIPTION
Still kinda brittle. No longer hardcodes the readme.com spec IDs in the publishing script, but has to fetch the existing specs via the readme API and try to match them up by `title`, as there isn't anything else to use that we're guaranteed to get in the spec metadata, e.g.
```
{
  title: 'Query API',
  source: 'cli',
  _id: '65399912b60e5a0669d43e5d',
  version: '65399912b60e5a0669d43ee9',
  lastSynced: '2023-08-30T21:57:49.138Z',
  category: null,
  type: 'oas',
  id: '65399912b60e5a0669d43e5d'
}
```