### PR TITLE
Add openapi to delete staging paths

### DIFF
--- a/.github/workflows/rdme-delete-staging.yml
+++ b/.github/workflows/rdme-delete-staging.yml
@@ -5,6 +5,7 @@ on:
       - closed
     paths:
       - 'reference/**'
+      - 'openapi/**'
       - '.github/actions/**'
       - '.github/workflows/rdme-staging.yml'
 


### PR DESCRIPTION
noticed that delete-staging wasn't running on PRs that included openapi/, so now it's here