### PR TITLE
Fix: events per request limit in /track is 200 instead of 50

### DIFF
--- a/reference/Ingestion API/events/track-event.md
+++ b/reference/Ingestion API/events/track-event.md
@@ -11,7 +11,7 @@ Prefer to use /import over /track where you can. We only recommend /track for cl
 
 |  | /track | /import |
 |---|---|---|
-| Events per request | 50 | 2000 |
+| Events per request | 200 | 2000 |
 | Authentication | Project Token, intended for untrusted clients. | Project Secret, intended for server-side integration. |
 | Compression | None | Gzip allowed |
 | Content-Type | application/x-www-form-urlencoded | application/json or application/x-ndjson |


### PR DESCRIPTION
Based on the code https://github.com/mixpanel/analytics/blob/c4a12b4ccbbeaa05b723b00d541f7bf2de685a83/go/src/mixpanel.com/ingestion/api/handlers/constants.go#L4