### PR TITLE
Update build-an-integration.md

### DIFF
--- a/pages/docs/cohort-sync/build-an-integration.md
+++ b/pages/docs/cohort-sync/build-an-integration.md
@@ -57,7 +57,7 @@ Sync your internal data dictionary or tracking plan with Mixpanel using the [Lex
 
 # Make your Integration Successful
 ### QA your Code
-For integrations sending events to Mixpanel, our Events page (see demo page [here](https://mixpanel.com/project/2195193/view/139237/app/events)) can be a great way to test if everything is working as expected.
+For integrations sending events to Mixpanel, our [Events page](https://mixpanel.com/report/events) can be a great way to test if everything is working as expected.
 
 ### Document Your Integration
 Customer-facing documentation that explains, which use cases your integration helps to solve and how to set it up, will increase the utilization of your integration.

--- a/pages/docs/cohort-sync/build-an-integration.md
+++ b/pages/docs/cohort-sync/build-an-integration.md
@@ -57,7 +57,7 @@ Sync your internal data dictionary or tracking plan with Mixpanel using the [Lex
 
 # Make your Integration Successful
 ### QA your Code
-For integrations sending events to Mixpanel, our [Events](/docs/users/overview) page can be a great way to test if everything is working as expected.
+For integrations sending events to Mixpanel, our Events page (see demo page [here](https://mixpanel.com/project/2195193/view/139237/app/events)) can be a great way to test if everything is working as expected.
 
 ### Document Your Integration
 Customer-facing documentation that explains, which use cases your integration helps to solve and how to set it up, will increase the utilization of your integration.


### PR DESCRIPTION
updated the link to the "Events" page under the QA your code section. It was pointing to our Users page instead... but I can't find the Events page in our docs, so I'm referencing our demo project...