### PR TITLE
Update facebook-ads.md

### DIFF
--- a/pages/docs/cohort-sync/integrations/facebook-ads.md
+++ b/pages/docs/cohort-sync/integrations/facebook-ads.md
@@ -67,7 +67,7 @@ Facebook excludes cohort members from the audience if they are unable to match t
 
 ## Troubleshooting Errors
 
-Below are some common blocking errors that may occur when authorizing or using this connection:
+Below are some common blocking errors (e.g. Error Message: Invalid OAuth 2.0 Access Token) that may occur when authorizing or using this connection:
 
 #### Login Token Expired. Please disconnect and reconnect from Integrations Page.
 


### PR DESCRIPTION
Adding example error message (Invalid OAuth 2.0 Access Token) that can show up in the connector when token is expired or invalid