### PR TITLE
Update track limit in ingestion OpenAPI spec to 200

### DIFF
--- a/openapi/src/ingestion.openapi.yaml
+++ b/openapi/src/ingestion.openapi.yaml
@@ -315,7 +315,7 @@ paths:
               "h-1": "/track",
               "h-2": "/import",
               "0-0": "Events per request",
-              "0-1": "50",
+              "0-1": "200",
               "0-2": "2000",
               "1-0": "Authentication",
               "1-1": "Project Token, intended for untrusted clients.",


### PR DESCRIPTION
Based on https://github.com/mixpanel/docs/pull/694

Right now there's two different limits because the docs show limits from both the OpenAPI spec and track-event.md.

Screenshot of existing API reference confusion:
![image](https://github.com/mixpanel/docs/assets/1560444/25a326ca-e3d5-4459-bdd4-8e793388126a)
