### PR TITLE
Fixed Slack authorization URL

### DIFF
--- a/pages/docs/features/advanced.md
+++ b/pages/docs/features/advanced.md
@@ -67,7 +67,7 @@ The Mixpanel application for Slack will also automatically unfurl a preview of 
 
 ### Enable the Integration
 
-To enable the integration, log in to both Mixpanel and Slack, then click [here](https://mixpanel.com/slack/oauth) to authorize the slack workspace: 
+To enable the integration, log in to both Mixpanel and Slack, then click [here](https://mixpanel.com/slack/oauth?slack_v2=true) to authorize the slack workspace: 
 
 ![/Screen_Shot_2020-06-15_at_10.41.00_PM.png](/Screen_Shot_2020-06-15_at_10.41.00_PM.png)
 


### PR DESCRIPTION
The URL listed in the Slack integration do was out of date