### PR TITLE
Update ingestion.openapi.yaml

### DIFF
--- a/openapi/src/ingestion.openapi.yaml
+++ b/openapi/src/ingestion.openapi.yaml
@@ -755,12 +755,12 @@ paths:
                     {
                         "$token": "YOUR_PROJECT_TOKEN",
                         "$distinct_id": "13793",
-                        "$add": { "Coins Gathered": 12 }
+                        "$set": { "Coins Gathered": 12 }
                     },
                     {
                         "$token": "YOUR_PROJECT_TOKEN",
                         "$distinct_id": "13794",
-                        "$add": { "Coins Gathered": 13 }
+                        "$set": { "Coins Gathered": 13 }
                     }
                 ]
       responses:


### PR DESCRIPTION
For Ingestion API /engage Batch Profile updates: https://developer.mixpanel.com/reference/profile-batch-update

The example to show the $add operation has caused some confusions with users who are looking to set profile properties instead of incremental properties. 

Changing the example operations to $set instead.

Before:
![Screenshot 2023-12-01 at 10 19 19 AM](https://github.com/mixpanel/docs/assets/6880495/8e9c44d7-e132-4a59-bb73-d19fc5a91d28)

After:
![image](https://github.com/mixpanel/docs/assets/6880495/14c4c5a0-5554-48f9-b625-4eec3e29ffcb)
