### PR TITLE
Update stripe.mdx

### DIFF
--- a/pages/docs/tracking-methods/integrations/stripe.mdx
+++ b/pages/docs/tracking-methods/integrations/stripe.mdx
@@ -28,7 +28,7 @@ Paste in the following code, which accepts Stripe's webhook format, and forwards
           'event': req['type'],
           'properties': {
             '$insert_id': req['id'],
-            '$device_id': req['data']['object'].get('customer', ''),
+            '$device_id': req['data']['object'].get('customer', ''), # If your project is on Original ID Merge, you would specify distinct_id for the user identifier
             'time': req['created'],
             **req['data']['object']
           }


### PR DESCRIPTION
Events with $device_id only to Ingestion API /import works for projects on Simplified ID Merge (works for associating it with a user). 
However, for projects on Original ID Merge, distinct_id will need to be specified for /import to associate it with a user.  
Adding a comment to the example Google Cloud function script to call this out.