### PR TITLE
Update moving boards changelog

### DIFF
--- a/pages/changelogs/2023-07-27-move.mdx
+++ b/pages/changelogs/2023-07-27-move.mdx
@@ -8,7 +8,7 @@ date: "2023-07-27"
 ---
 Introducing Move, a powerful new feature that allows you to move Boards from one project to another, or one organization to another. Simply hover over the menu icon in the top right corner and mouse over “Move to” to move a Board to a new project. 
 This feature is available on all plan types at no additional charge. Permissions for this feature are managed by group admins, who have the ability to allow moving Boards between projects, or even organizations. 
-It's important to note that if you would like a version of the Board to stay in the parent project, duplicate it and move the new duplicate Board.
+It's important to note that if you would like a version of the Board to stay in the parent project, duplicate it and move the new duplicate Board. Moving boards from projects based in the US -> EU as well as EU -> US is unavailable at this time.
  
 ![changelog Image](/changelog/Demo_mv_x_proj.gif)
 


### PR DESCRIPTION
Users cannot move boards between US and EU based projects - only from US to US and EU to EU