### PR TITLE
make `trackAutomaticEvents` as `false` by default

### DIFF
--- a/pages/docs/quickstart/connect-your-data.mdx
+++ b/pages/docs/quickstart/connect-your-data.mdx
@@ -292,7 +292,7 @@ import React from "react";
 import { Button, SafeAreaView } from "react-native";
 import { Mixpanel } from "mixpanel-react-native";
 
-const trackAutomaticEvents = true;
+const trackAutomaticEvents = false;
 const mixpanel = new Mixpanel("Your Token", trackAutomaticEvents);
 mixpanel.init();
 
@@ -333,7 +333,7 @@ class _YourClassState extends State<YourClass> {
   Future<void> initMixpanel() async {
     // Replace with your Project Token
     // Once you've called this method once, you can access `mixpanel` throughout the rest of your application.
-    mixpanel = await Mixpanel.init("Your Token", trackAutomaticEvents: true);
+    mixpanel = await Mixpanel.init("Your Token", trackAutomaticEvents: false);
   }
 ```
 
@@ -350,7 +350,7 @@ For more options, see the reference and code for each SDK in [Github](https://gi
 
 - (BOOL)application:(UIApplication _)application didFinishLaunchingWithOptions:(NSDictionary _)launchOptions {
   ...
-  Mixpanel *mixpanel = [Mixpanel sharedInstanceWithToken:@"YOUR_TOKEN" trackAutomaticEvents: YES];
+  Mixpanel *mixpanel = [Mixpanel sharedInstanceWithToken:@"YOUR_TOKEN" trackAutomaticEvents: NO];
   [mixpanel track:@"Signed Up" properties:@{
   @"Signup Type": @"Referral"
   }];
@@ -375,7 +375,7 @@ func application(_ application: UIApplication,
                  didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
     ...
     // Replace with your Project Token
-    Mixpanel.initialize(token: "Your Token", trackAutomaticEvents: true)
+    Mixpanel.initialize(token: "Your Token", trackAutomaticEvents: false)
     Mixpanel.mainInstance().track(event: "Signed Up", properties: [
         "Signup Type": "Referral",
     ])


### PR DESCRIPTION
automatically collecting common mobile events is a legacy feature so make it `false` by default to be consistent.
reference: https://docs.mixpanel.com/docs/tracking-methods/sdks/android#legacy-automatically-tracked-events