### PR TITLE
Remove 500 limit warning from sdk docs because it's no longer relevan…

### DIFF
--- a/pages/docs/tracking-methods/sdks/android.md
+++ b/pages/docs/tracking-methods/sdks/android.md
@@ -93,9 +93,6 @@ In general, if you use [identify](https://mixpanel.github.io/mixpanel-android/co
 ## Call Reset at Logout
 [Reset](https://mixpanel.github.io/mixpanel-android/com/mixpanel/android/mpmetrics/MixpanelAPI.html#reset()) generates a new random distinct_id and clears super properties. Call reset to clear data attributed to a user when that user logs out. This allows you to handle multiple users on a single device. For more information about maintaining user identity, see the [Identifying Users](/docs/tracking-methods/id-management/identifying-users) article.
 
-Note: If you're using our [original ID Merge](/docs/tracking-methods/id-management/identifying-users#simplified-vs-original-id-merge), calling reset frequently can lead to users quickly exceeding the 500 distinct_id per identity cluster limit. Once the 500 limit is reached you will no longer be able to add additional distinct_ids to the users identity cluster. In that case, reset should only be used if multiple users share a device. 
-
-
 ## Storing User Profiles
 
 In addition to events, you can store user profiles in Mixpanel's [Behavioral Analytics](/docs/data-structure/user-profiles) product. Profiles are persistent sets of properties that describe a user - things like name, email address, and signup date. You can use profiles to explore and segment users by who they are, rather than what they did.

--- a/pages/docs/tracking-methods/sdks/flutter.md
+++ b/pages/docs/tracking-methods/sdks/flutter.md
@@ -99,8 +99,6 @@ mixpanel.identify("13791");
 ### Call Reset at Logout
 [reset](https://mixpanel.github.io/mixpanel-flutter/mixpanel_flutter/Mixpanel/reset.html)  generates a new random distinct_id and clears super properties. Call reset to clear data attributed to a user when that user logs out. This allows you to handle multiple users on a single device. For more information about maintaining user identity, see the [Identifying Users](/docs/tracking-methods/id-management/identifying-users) article article.
 
-Note: Calling reset frequently can lead to users quickly exceeding the 500 distinct_id per identity cluster limit. Once the 500 limit is reached you will no longer be able to add additional distinct_ids to the users identity cluster.
-
 ## Storing User Profiles
 
 In addition to events, you can store user profiles in Mixpanel's [Behavioral Analytics](https://mixpanel.com/people/) product. Profiles are persistent sets of properties that describe a user - things like name, email address, and signup date. You can use profiles to explore and segment users by who they are, rather than what they did.

--- a/pages/docs/tracking-methods/sdks/ios.md
+++ b/pages/docs/tracking-methods/sdks/ios.md
@@ -93,8 +93,6 @@ Call `identify` when you know the identity of the current user, typically after 
 
 Reset generates a new random distinct_id and clears super properties. Call reset to clear data attributed to a user when that user logs out. This allows you to handle multiple users on a single device. For more information about maintaining user identity, see the [Identifying Users](/docs/tracking-methods/id-management/identifying-users) article.
 
-Note: If you're using our [original ID Merge](/docs/tracking-methods/id-management/identifying-users#simplified-vs-original-id-merge), calling reset frequently can lead to users quickly exceeding the 500 distinct_id per identity cluster limit. Once the 500 limit is reached you will no longer be able to add additional distinct_ids to the users identity cluster. In that case, reset should only be used if multiple users share a device. 
-
 Beginning with version v3.6.2, Mixpanel no longer uses the IFA(ID for Advertisers) but uses a randomly generated UUID as the default distinct ID instead. After you call reset, Mixpanel generates a new distinct_id.
 
 If you want to use IFV(identifierForVendor) as the distinct_id, you can set

--- a/pages/docs/tracking-methods/sdks/react-native.md
+++ b/pages/docs/tracking-methods/sdks/react-native.md
@@ -94,8 +94,6 @@ mixpanel.identify("13791");
 ### Call Reset at Logout
 [reset](https://mixpanel.github.io/mixpanel-react-native/Mixpanel.html#reset)  generates a new random distinct_id and clears super properties. Call reset to clear data attributed to a user when that user logs out. This allows you to handle multiple users on a single device. For more information about maintaining user identity, see the [Identifying Users](/docs/tracking-methods/id-management/identifying-users) article.
 
-Note: Calling reset frequently can lead to users quickly exceeding the 500 distinct_id per identity cluster limit. Once the 500 limit is reached you will no longer be able to add additional distinct_ids to the users identity cluster.
-
 ```javascript Javascript
 mixpanel.reset();
 ```

--- a/pages/docs/tracking-methods/sdks/swift.md
+++ b/pages/docs/tracking-methods/sdks/swift.md
@@ -83,8 +83,6 @@ Mixpanel.mainInstance().identify(distinctId: "13793");
 ### Call Reset on Logout
 Reset generates a new random distinct_id and clears super properties. Call reset to clear data attributed to a user when that user logs out. This allows you to handle multiple users on a single device. For more information about maintaining user identity, see the [Identifying Users](/docs/tracking-methods/id-management/identifying-users) article.
 
-Note: Calling reset frequently can lead to users quickly exceeding the 500 distinct_id per identity cluster limit. Once the 500 limit is reached you will no longer be able to add additional distinct_ids to the users identity cluster.
-
 Beginning with version v2.7.7, Mixpanel no longer uses the IFA(ID for Advertisers) but uses a randomly generated UUID as the default distinct ID instead. After you call reset, Mixpanel generates a new distinct_id.
 
 If you want to use IFV(identifierForVendor) as the distinct_id, you can set

--- a/pages/docs/tracking-methods/sdks/unity.md
+++ b/pages/docs/tracking-methods/sdks/unity.md
@@ -119,9 +119,6 @@ Mixpanel.Identify('13793');
 ### Call Reset at Logout
 [Reset](http://mixpanel.github.io/mixpanel-unity/api-reference/classmixpanel_1_1_mixpanel.html#af80b55f985b94780ec983dc6c1210d6b) generates a new random distinct_id and clears super properties. Call reset to clear data attributed to a user when that user logs out. This allows you to handle multiple users on a single device. For more information about maintaining user identity, see the [Identifying Users](/docs/tracking-methods/id-management/identifying-users) article.
 
-Note: Calling reset frequently can lead to users quickly exceeding the 500 distinct_id per identity cluster limit. Once the 500 limit is reached you will no longer be able to add additional distinct_ids to the users identity cluster.
-
-
 ## Storing User Profiles
 
 In addition to events, you can store user profiles in Mixpanel's [User Analytics](https://mixpanel.com/people/) product. Profiles are persistent sets of properties that describe a user—things like name, email address, and signup date. You can use profiles to explore and segment users by who they are, rather than what they did. You can also use profiles to send messages, such as emails, SMS, or push notifications.


### PR DESCRIPTION
…t with SImplified ID Merge

It's still relevant for Original ID Merge, but I'm making the assumption here that most people who are still on Original ID Merge have long since implemented already and are less commonly looking at these docs (since it's been nearly a year since launching Simplified).

So I'd rather optimize here for new users, who are all on Simplified and don't need to worry about this.