### PR TITLE
Update billing.md

### DIFF
--- a/pages/docs/pricing/billing.md
+++ b/pages/docs/pricing/billing.md
@@ -24,7 +24,6 @@ Certain events and API updates are non-qualifying and excluded from the Monthly 
 - `$identify`
 - `$create_alias`
 - `$merge`
-- `$web_event`
 - User profile creation/updates
 
 ### Estimate Events Usage


### PR DESCRIPTION
Removing $web_event from our excluded MTU events, as this was deprecated long ago and could cause confusion.