### PR TITLE
add quickstart link

### DIFF
--- a/pages/docs/tracking-methods/sdks/javascript.md
+++ b/pages/docs/tracking-methods/sdks/javascript.md
@@ -2,6 +2,8 @@
 
 ## Getting Started
 
+Please refer to our [Quickstart Guide](/docs/quickstart/connect-your-data?sdk=javascript).
+
 The [Full API Reference](https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md#mixpanel), [Library Source Code](https://github.com/mixpanel/mixpanel-js), and an [Example Application](https://github.com/mixpanel/mixpanel-js/tree/master/examples) is documented in our GitHub repo.
 
 ## Track Events


### PR DESCRIPTION
add link back in the quickstart page which shows the snippet / npm installation.

this link is present for all the other SDK pages, so we should have it here too.