### PR TITLE
Update export.openapi.yaml

### DIFF
--- a/openapi/src/export.openapi.yaml
+++ b/openapi/src/export.openapi.yaml
@@ -39,7 +39,7 @@ paths:
           name: limit
           schema:
             type: integer
-          description: The max number of events to be returned.
+          description: The max number of events to be returned. Cannot be over 100000.
         - in: query
           name: event
           schema:


### PR DESCRIPTION
The max number that can be input is 100000 and it is not clear on the doc that if you insert a limit over the 100K number then a 400 error will return.