### PR TITLE
Adjust UI for mobile web on Search input

### DIFF
--- a/components/Search/Search.module.scss
+++ b/components/Search/Search.module.scss
@@ -12,3 +12,13 @@
     display: flex;
     flex-direction: row;
 }
+
+@media (max-width: 768px) {
+    .searchBar {
+        display: none;
+    }
+    
+    .icon {
+        width: 20px;
+    }
+}


### PR DESCRIPTION
See [this thread](https://mixpanel.slack.com/archives/C050U6CQRLZ/p1714666105191899). Our logo was getting moved over, so on mobile web, we're going to just show the icon for initiating a new search.