### PR TITLE
Add support for thumbnails and videos in changelog list. Also pagination.

### DIFF
--- a/components/changelog-index.js
+++ b/components/changelog-index.js
@@ -1,7 +1,39 @@
 import { getPagesUnderRoute } from "nextra/context";
+import ExtendedButton from '/components/ExtendedButton/ExtendedButton'
 import Link from "next/link";
 
-export default function ChangelogIndex({ more = "Read more" }) {
+const renderMedia = (page) => {
+  if (page.frontMatter?.thumbnail) {
+    return <img src={page.frontMatter.thumbnail} 
+                alt="Thumbnail" 
+                style={{ maxWidth: '560px', width:"100%", borderRadius: "16px", marginBottom: "16px"}} 
+                className="max-w-full h-auto" />;
+  } else if (page.frontMatter?.video) {
+    const videoURL = page.frontMatter.video;
+    let embedURL;
+
+    if (videoURL.includes("youtube.com") || videoURL.includes("youtu.be")) {
+      const videoId = videoURL.split('v=')[1] ? videoURL.split('v=')[1].split('&')[0] : videoURL.split('/').pop();
+      embedURL = `https://www.youtube.com/embed/${videoId}`;
+    } else if (videoURL.includes("loom.com")) {
+      const videoId = videoURL.split('/').pop();
+      embedURL = `https://www.loom.com/embed/${videoId}`;
+    }
+
+    return (
+      <iframe
+        src={embedURL}
+        style = {{maxWidth:"560px", width:"100%", aspectRatio: 16 / 9, height:"auto", borderRadius: "16px", marginBottom: "16px"}}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        title="Video"
+      ></iframe>
+    );
+  }
+  return "";
+};
+
+export default function ChangelogIndex() {
   return getPagesUnderRoute("/changelogs").map((page) => {
     return (
       <div key={page.route} className="mb-10">
@@ -14,22 +46,15 @@ export default function ChangelogIndex({ more = "Read more" }) {
             {page.meta?.title || page.frontMatter?.title || page.name}
           </Link>
         </h3>
-        <p className="opacity-80 mt-6 leading-7">
-          {page.frontMatter?.description}{" "}
-          <span className="inline-block">
-            <Link
-              href={page.route}
-              className="text-[color:hsl(var(--nextra-primary-hue),100%,50%)] underline underline-offset-2 decoration-from-font"
-            >
-              {more + " →"}
-            </Link>
-          </span>
-        </p>
         {page.frontMatter?.date ? (
-          <p className="opacity-50 text-sm mt-6 leading-7">
+          <p className="opacity-50 text-sm mt-1 mb-2 leading-7">
             {page.frontMatter.date}
           </p>
         ) : null}
+        
+        {renderMedia(page)}
+
+        <ExtendedButton  title="Read more" link={page.route}></ExtendedButton>
       </div>
     );
   });

--- a/components/changelog-index.js
+++ b/components/changelog-index.js
@@ -18,7 +18,7 @@ const renderMedia = (page) => {
       embedURL = `https://www.youtube.com/embed/${videoId}`;
     } else if (videoURL.includes("loom.com")) {
       const videoId = videoURL.split('/').pop();
-      embedURL = `https://www.loom.com/embed/${videoId}`;
+      embedURL = `https://www.loom.com/embed/${videoId}?hideEmbedTopBar=true`;
     }
 
     return (

--- a/components/changelog-index.js
+++ b/components/changelog-index.js
@@ -52,7 +52,7 @@ export default function ChangelogIndex({ more = "Read more" }) {
   };
 
   return (
-    <div>
+    <div style={{display: 'block', maxWidth: '560px', width:'100%', marginLeft: 'auto', marginRight: 'auto',  alignItems: 'center' }}>
       {displayedPages.map((page) => (
         <div key={page.route} className="mb-10">
           <h3>

--- a/components/changelog-index.js
+++ b/components/changelog-index.js
@@ -42,7 +42,6 @@ export default function ChangelogIndex({ more = "Read more" }) {
 
   // Load initial or additional pages
   useEffect(() => {
-    console.log(pageIndex);  // Check the current page index
     const morePages = allPages.slice(pageIndex, pageIndex + itemsPerPage);
     setDisplayedPages(prev => [...prev, ...morePages]);
   }, [pageIndex]);

--- a/components/changelog-index.js
+++ b/components/changelog-index.js
@@ -1,3 +1,4 @@
+import React, { useState, useEffect } from 'react';
 import { getPagesUnderRoute } from "nextra/context";
 import ExtendedButton from '/components/ExtendedButton/ExtendedButton'
 import Link from "next/link";
@@ -33,29 +34,77 @@ const renderMedia = (page) => {
   return "";
 };
 
-export default function ChangelogIndex() {
-  return getPagesUnderRoute("/changelogs").map((page) => {
-    return (
-      <div key={page.route} className="mb-10">
-        <h3>
-          <Link
-            href={page.route}
-            style={{ color: "inherit", textDecoration: "none" }}
-            className="block font-semibold mt-8 text-2xl "
-          >
-            {page.meta?.title || page.frontMatter?.title || page.name}
-          </Link>
-        </h3>
-        {page.frontMatter?.date ? (
-          <p className="opacity-50 text-sm mt-1 mb-2 leading-7">
-            {page.frontMatter.date}
-          </p>
-        ) : null}
-        
-        {renderMedia(page)}
+export default function ChangelogIndex({ more = "Read more" }) {
+  const allPages = getPagesUnderRoute("/changelogs");
+  const itemsPerPage = 10;
+  const [displayedPages, setDisplayedPages] = useState([]);
+  const [pageIndex, setPageIndex] = useState(0);
 
-        <ExtendedButton  title="Read more" link={page.route}></ExtendedButton>
-      </div>
-    );
-  });
+  // Load initial or additional pages
+  useEffect(() => {
+    console.log(pageIndex);  // Check the current page index
+    const morePages = allPages.slice(pageIndex, pageIndex + itemsPerPage);
+    setDisplayedPages(prev => [...prev, ...morePages]);
+  }, [pageIndex]);
+  
+  const loadMore = () => {
+    setPageIndex(prev => prev + itemsPerPage);
+  };
+
+  return (
+    <div>
+      {displayedPages.map((page) => (
+        <div key={page.route} className="mb-10">
+          <h3>
+            <Link
+              href={page.route}
+              style={{ color: "inherit", textDecoration: "none" }}
+              className="block font-semibold mt-8 text-2xl "
+            >
+              {page.meta?.title || page.frontMatter?.title || page.name}
+            </Link>
+          </h3>
+          {page.frontMatter?.date ? (
+            <p className="opacity-50 text-sm mt-1 mb-2 leading-7">
+              {page.frontMatter.date}
+            </p>
+          ) : null}
+          
+          {renderMedia(page)}
+
+          <p className="opacity-80 mt-6 leading-7">
+          {page.frontMatter?.description}{" "}
+          <span className="inline-block">
+            <Link
+              href={page.route}
+              className="text-[color:hsl(var(--nextra-primary-hue),100%,50%)] underline underline-offset-2 decoration-from-font"
+            >
+              {more + " →"}
+            </Link>
+          </span>
+        </p>
+        </div>
+      ))}
+    {pageIndex + itemsPerPage < allPages.length && (
+      <button onClick={loadMore} className="text-white 
+      
+      // Background
+      bg-gradient-to-b from-purple50 to-purple100 hover:from-purple50 hover:to-purple100 active:from-purple50 active:to-purple140
+  
+      // Shadow
+      shadow-sm hover:shadow-md
+  
+      // Shadow
+      rounded-full hover:rounded-lg 
+      
+      // Font 
+      font-medium  text-md 
+      
+      // Padding
+      px-7 py-2.5">
+        Load More
+      </button>
+    )}
+  </div>
+  );
 }

--- a/pages/changelogs/2024-03-05-funnels-alerts.mdx
+++ b/pages/changelogs/2024-03-05-funnels-alerts.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-05T14:59:02.165Z"
 updatedAt: "2024-03-05T14:59:02.165Z"
 date: "2024-03-05"
+video: "https://www.loom.com/embed/0284fcd216c74397966996fbb558b053"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/0284fcd216c74397966996fbb558b053"

--- a/pages/changelogs/2024-03-05-funnels-behaviors.mdx
+++ b/pages/changelogs/2024-03-05-funnels-behaviors.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-05T14:59:02.165Z"
 updatedAt: "2024-03-05T14:59:02.165Z"
 date: "2024-03-05"
+video: "https://www.loom.com/embed/e6e9806db88b448bb82044033ac052cf"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/e6e9806db88b448bb82044033ac052cf"

--- a/pages/changelogs/2024-03-05-funnels-ttc.mdx
+++ b/pages/changelogs/2024-03-05-funnels-ttc.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-05T14:59:02.165Z"
 updatedAt: "2024-03-05T14:59:02.165Z"
 date: "2024-03-05"
+video: "https://www.loom.com/embed/5150be7a7b194de0ac538ff85c35c3ce"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/5150be7a7b194de0ac538ff85c35c3ce"

--- a/pages/changelogs/2024-03-05-revenue-conversion.mdx
+++ b/pages/changelogs/2024-03-05-revenue-conversion.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-05T14:59:02.165Z"
 updatedAt: "2024-03-05T14:59:02.165Z"
 date: "2024-03-05"
+video: "https://www.loom.com/embed/e041e17a02d4429b84304ba0ce1345dc"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/e041e17a02d4429b84304ba0ce1345dc"

--- a/pages/changelogs/2024-03-05-xtd.md
+++ b/pages/changelogs/2024-03-05-xtd.md
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-05T14:59:02.165Z"
 updatedAt: "2024-03-05T14:59:02.165Z"
 date: "2024-03-05"
+thumbnail: "/changelog/xtd.png"
 ---
 Mixpanel now supports the ability to set the timeframe of your visualization by “X”-to-date:
 

--- a/pages/changelogs/2024-03-07-benchmark.mdx
+++ b/pages/changelogs/2024-03-07-benchmark.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-07T14:59:02.165Z"
 updatedAt: "2024-03-07T14:59:02.165Z"
 date: "2024-03-07"
+thumbnail: "/benchmarks-changelog.png"
 ---
 ![changelog Image](/benchmarks-changelog.png)
 

--- a/pages/changelogs/2024-03-11-retention-behaviors.mdx
+++ b/pages/changelogs/2024-03-11-retention-behaviors.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-11T17:59:02.165Z"
 updatedAt: "2024-03-11T17:59:02.165Z"
 date: "2024-03-11"
+video: "https://www.loom.com/embed/dd4042654e6f46039d011a680fe93948"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/dd4042654e6f46039d011a680fe93948"

--- a/pages/changelogs/2024-03-11-sub-to-boards.mdx
+++ b/pages/changelogs/2024-03-11-sub-to-boards.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-11T14:59:02.165Z"
 updatedAt: "2024-03-11T14:59:02.165Z"
 date: "2024-03-11"
+thumbnail: "/changelog/subscribetoboards.png"
 ---
 Boards are a useful tool to collect a series of reports in one place, but they shouldn't be a set and forget experience. It's important to stay in the loop with how these key metrics are moving.
 

--- a/pages/changelogs/2024-03-14-borrowed-properties.mdx
+++ b/pages/changelogs/2024-03-14-borrowed-properties.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-14T14:59:02.165Z"
 updatedAt: "2024-03-14T14:59:02.165Z"
 date: "2024-03-14"
+video: "https://www.loom.com/embed/d45c325a7ee544a9965e90c3a5127257?sid=0cc8f226-72a4-4817-bd6d-13732a3b4237"
 ---
 <div style={{position: "relative", paddingBottom: "56.25%", height: 0}}><iframe src="https://www.loom.com/embed/d45c325a7ee544a9965e90c3a5127257?sid=0cc8f226-72a4-4817-bd6d-13732a3b4237" frameBorder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowFullScreen style={{position: "absolute", top: 0, left: 0, width: "100%", height: "100%"}}></iframe></div>
 

--- a/pages/changelogs/2024-03-27-spark.mdx
+++ b/pages/changelogs/2024-03-27-spark.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-03-27T14:59:02.165Z"
 updatedAt: "2024-03-27T14:59:02.165Z"
 date: "2024-03-27"
+thumbnail: "/changelog/spark-changelog.png"
 ---
 
 ![spark](/changelog/spark-changelog.png)

--- a/pages/changelogs/2024-04-03-plot-metrics-in-insights.mdx
+++ b/pages/changelogs/2024-04-03-plot-metrics-in-insights.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-04-03T14:59:02.165Z"
 updatedAt: "2024-04-03T14:59:02.165Z"
 date: "2024-04-03"
+video: "https://www.loom.com/embed/81c25f63005d4d0da8d06c1558ac1c70"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/81c25f63005d4d0da8d06c1558ac1c70"

--- a/pages/changelogs/2024-04-03-save-funnel-retention-behaviors.mdx
+++ b/pages/changelogs/2024-04-03-save-funnel-retention-behaviors.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-04-03T18:59:02.165Z"
 updatedAt: "2024-04-03T18:59:02.165Z"
 date: "2024-04-03"
+video: "https://www.loom.com/embed/e84c62b2454d496b960fb0fdb09b9785"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/e84c62b2454d496b960fb0fdb09b9785"

--- a/pages/changelogs/2024-04-18-ai-chatbot-search-in-docs.mdx
+++ b/pages/changelogs/2024-04-18-ai-chatbot-search-in-docs.mdx
@@ -5,6 +5,7 @@ hidden: false
 createdAt: "2024-04-08T18:59:02.165Z"
 updatedAt: "2024-04-08T18:59:02.165Z"
 date: "2024-04-08"
+video: "https://www.loom.com/embed/3407a37ce1634f51b94b380c40c96306"
 ---
 <div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
     <iframe src="https://www.loom.com/embed/3407a37ce1634f51b94b380c40c96306"


### PR DESCRIPTION
This is a first attempt at bringing thumbnails to the list view of the changelog page. How to use it:

In the frontMatter section at the top of each new change log, either set a `thumbnail:` URL or a `video:` URL. The list view will pick this up and present it. I've set a few for the last 20 or so change log items. Here's an example:

`
video: "https://www.loom.com/embed/3407a37ce1634f51b94b380c40c96306"
`

I also used some chatgpt wizardry to add pagination, as loading too many loom embeds would slow things down. I'm not a web person and can't vet this, so it would be good to get some eyes on this portion especially.

<img width="888" alt="Screenshot 2024-05-08 at 12 36 02 PM" src="https://github.com/mixpanel/docs/assets/1782269/b8f2619b-67ed-46dc-9e41-4e768790368b">

