### PR TITLE
Update geolocate config nodejs.md

### DIFF
--- a/pages/docs/tracking-methods/sdks/nodejs.md
+++ b/pages/docs/tracking-methods/sdks/nodejs.md
@@ -59,7 +59,7 @@ It is therefore important to pass IP as a property in server-side implementation
 
 ```javascript
 const Mixpanel = require('mixpanel');
-const mixpanel = Mixpanel.init('<YOUR_TOKEN>', { geolocate: true });
+const mixpanel = Mixpanel.init('<YOUR_TOKEN>', { geolocate: false });
 
 // track an event with optional properties
 mixpanel.track('event name', {
@@ -68,7 +68,7 @@ mixpanel.track('event name', {
 });
 ```
 
-The geolocate boolean setting needs to be `true` for Mixpanel to infer the location based on the ip property provided in the event payload.
+The geolocate boolean setting needs to be `false` for Mixpanel to infer the location based on the ip property provided in the event payload.
 
 Note that tracking with Node in an async serverless implementation requires you to wait for the Mixpanel request to complete. The easiest way to do this would be to pass in in a callback as a 3rd parameter into `track` and return a promise that is resolved when the request is sent.
 


### PR DESCRIPTION
'geolocate' config must be set to 'false' for Mixpanel to take the 'ip' property within the event payload instead of the ip of the server sending the request.