### PR TITLE
Fix feedback collector

### DIFF
--- a/components/FeedbackCollector/FeedbackCollector.tsx
+++ b/components/FeedbackCollector/FeedbackCollector.tsx
@@ -11,11 +11,17 @@ export function FeedbackCollector() {
   const [gaveFeedback, setGaveFeedback] = useState(false);
 
   const handleFeedback = function (isPositive: boolean) {
+    // changelogs don't have h1s
     const props = {
-      title: document.querySelector(`h1`).textContent,
+      title: document.querySelector(`h1`)?.textContent || document.title,
     }
     track(isPositive ? `Docs Promoter` : `Docs Detractor`, props);
     setGaveFeedback(true);
+
+    // reset feedback to 5 seconds
+    setTimeout(() => {
+      setGaveFeedback(false);
+    }, 5000);
   };
 
   return (


### PR DESCRIPTION
h1s don't exist in changelogs, so check and add document.title instead.
in addition, reset the feedback to 5 seconds since it doesn't refresh page to page.