### PR TITLE
Update lexicon.mdx

### DIFF
--- a/pages/docs/data-governance/lexicon.mdx
+++ b/pages/docs/data-governance/lexicon.mdx
@@ -196,7 +196,7 @@ To show an event or property:
 
 ## Merging Data
 
-In Lexicon, project owners can merge events and event properties.
+In Lexicon, only project owners can merge events and event properties.
 
 Let's suppose your iOS app sends an event named “Purchase”, and your Android app sends an event named “purchase item”. Even though both events have the same function, you have to individually select them every time you build a report.
 


### PR DESCRIPTION
adding 'only' to project owners to lexicon > merge events section to make it more visible that other roles do not have this option