### PR TITLE
Fix link in Super Properties section to Properties page

### DIFF
--- a/pages/docs/tracking-methods/sdks/javascript.md
+++ b/pages/docs/tracking-methods/sdks/javascript.md
@@ -105,7 +105,7 @@ For domains that don't allow cross-subdomain cookies, you should be setting `cro
 
 It's very common to have certain properties that you want to include with each event you send. Generally, these are things you know about the user rather than about a specific event - for example, the user's age, gender, source, or initial referrer.
 
-To make things easier, you can register these properties as super properties. If you tell us just once that these properties are important, we will automatically include them with all events sent. Super properties are stored in a browser cookie, and will persist between visits to your site. Mixpanel already stores some information as super properties by default; see a full list of Mixpanel default properties [here](/docs/data-structure/property-reference#default-properties).
+To make things easier, you can register these properties as super properties. If you tell us just once that these properties are important, we will automatically include them with all events sent. Super properties are stored in a browser cookie, and will persist between visits to your site. Mixpanel already stores some information as super properties by default; see a full list of Mixpanel default properties [here](/docs/data-structure/property-reference/properties).
 
 To set super properties, call [`mixpanel.register()`](https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md#mixpanelregister).
 


### PR DESCRIPTION
Link pointed to default properties but that link was dead. Updated to point at the current Properties reference page.