### PR TITLE
[Session Replay] Added new features and minimum duration SDK option

### DIFF
--- a/pages/docs/session-replay/session-replay-web.md
+++ b/pages/docs/session-replay/session-replay-web.md
@@ -42,14 +42,17 @@ Click any point on a chart for Event and Funnel metrics, and select ‘View Repl
 The Replay Player allows you to watch replays, as well as:
 
 - Expand the player to full-screen
-- Copy a URL to share with your teammates
+- Copy a URL with or without a timestamp to share with your teammates
 - Change the playback speed
 - Automatically skip periods of the replay where user is inactive
+- See events in the replay timeline
+- Jump to different parts of the replay by clicking in the timeline
 
 The Replay Feed on the left of the player also allows you to:
 
-- sort replays by recency
-- search for replays by user's name / email, replay date, or user ID
+- Sort replays by recency, activity, or duration
+- Search for replays by user's name / email, replay date, user ID, or the name of an event in the replay
+- See a feed of events that occurred during each replay
 
 ## Implementation
 Session Replay is not enabled by default; enabling the feature requires instrumentation beyond the standard Mixpanel instrumentation. 

--- a/pages/docs/tracking-methods/sdks/javascript.md
+++ b/pages/docs/tracking-methods/sdks/javascript.md
@@ -400,6 +400,7 @@ If you already have the JS SDK installed, this is the only code change you need 
 | `record_mask_text_class` | CSS class name or regular expression for elements that will have their text contents masked. | `new RegExp('^(mp-mask\|fs-mask\|amp-mask\|rr-mask\|ph-mask)$')` <br/> (common industry mask classes) |
 | `record_mask_text_selector` | CSS selector for elements that will have their text contents masked. | `"*"` |
 | `record_max_ms` | Maximum length of a single replay in milliseconds. Up to 24 hours is supported. Once a replay has reached the maximum length, a new one will begin. | `86400000`<br/>(24 hours) |
+| `record_min_ms` | Minimum length of a single replay in milliseconds. Up to 8 seconds is supported. If a replay does not meet the minimum length, it will be discarded. | `0`<br/>(0 seconds) |
 | `record_sessions_percent` | Percentage of SDK initializations that will qualify for replay data capture. A value of "1" = 1%. | `0` |
 
 


### PR DESCRIPTION
## Summary

Added some new features on the main Session Replay Web page and updated the SDK docs to include the minimum recording setting.