### PR TITLE
[Changelog] update layout and formatting of changelog feed

### DIFF
--- a/components/changelog-index.js
+++ b/components/changelog-index.js
@@ -10,7 +10,6 @@ const renderMedia = (page) => {
         src={page.frontMatter.thumbnail}
         alt="Thumbnail"
         style={{
-          maxWidth: "560px",
           width: "100%",
           borderRadius: "16px",
           marginBottom: "16px",
@@ -36,7 +35,6 @@ const renderMedia = (page) => {
       <iframe
         src={embedURL}
         style={{
-          maxWidth: "560px",
           width: "100%",
           aspectRatio: 16 / 9,
           height: "auto",
@@ -72,41 +70,47 @@ export default function ChangelogIndex({ more = "Read more" }) {
   return (
     <div
       style={{
-        display: "block",
-        maxWidth: "560px",
-        width: "100%",
-        marginLeft: "auto",
-        marginRight: "auto",
+        display: "flex",
         alignItems: "center",
+        flexDirection: "column",
       }}
       className="changelogIndexContainer"
     >
       {displayedPages.map((page) => (
         <div key={page.route} className="changelogIndexItem">
-          <h3>
-            <Link
-              href={page.route}
-              style={{ color: "inherit", textDecoration: "none" }}
-              className="changelogItemTitle block"
-            >
-              {page.meta?.title || page.frontMatter?.title || page.name}
-            </Link>
-          </h3>
-          {page.frontMatter?.date ? (
-            <p className="changelogDate">{page.frontMatter.date}</p>
-          ) : null}
+          <div className="changelogIndexItemDate">
+            {page.frontMatter?.date ? (
+              <p className="changelogDate">{(new Date(page.frontMatter.date)).toLocaleDateString(undefined, {
+                year: "numeric",
+                month: "long",
+                day: "numeric"
+              })}</p>
+            ) : null}
+          </div>
 
-          {renderMedia(page)}
+          <div className="changelogIndexItemBody">
+            {renderMedia(page)}
 
-          <p className="opacity-80 mt-6 leading-7">
-            {page.frontMatter?.description}{" "}
-            <span className="inline-block">
-              <Link href={page.route} className="changelogReadMoreLink">
-                {more + " →"}
+            <h3>
+              <Link
+                href={page.route}
+                style={{ color: "inherit", textDecoration: "none" }}
+                className="changelogItemTitle block"
+              >
+                {page.meta?.title || page.frontMatter?.title || page.name}
               </Link>
-            </span>
-          </p>
-          <div className="changelogDivider nx-mt-16"></div>
+            </h3>
+
+            <p className="opacity-80 mt-6 leading-7">
+              {page.frontMatter?.description}{" "}
+              <span className="inline-block">
+                <Link href={page.route} className="changelogReadMoreLink">
+                  {more + " →"}
+                </Link>
+              </span>
+            </p>
+            <div className="changelogDivider nx-mt-16"></div>
+          </div>
         </div>
       ))}
       {pageIndex + itemsPerPage < allPages.length && (

--- a/pages/changelogs/2024-10-09-segment-coloring.mdx
+++ b/pages/changelogs/2024-10-09-segment-coloring.mdx
@@ -6,21 +6,39 @@ createdAt: "2024-10-09T19:59:02.165Z"
 updatedAt: "2024-10-09T19:59:02.165Z"
 date: "2024-10-09"
 thumbnail: "/changelog/segment-coloring.png"
+description: "Mixpanel now allows you to select the colors of various segments in your reports. You can choose the color for a particular segment by clicking the legend at the top of the chart. Choose between colors that exist in the theme, or choose an entirely separate color."
 ---
+
 ![segment coloring](/changelog/segment-coloring.png)
 
 Mixpanel now allows you to select the colors of various segments in your reports. You can choose the color for a particular segment by clicking the legend at the top of the chart. Choose between colors that exist in the theme, or choose an entirely separate color.
 
 Some common uses for this:
+
 - Highlight a particular segment for emphasis
 - On boards with the same breakdown repeatedly, set the colors for segments so they can be aligned across the board
 
-<div style={{position: 'relative', paddingBottom: '64.90384615384616%', height: 0}}>
-    <iframe src="https://www.loom.com/embed/164cee809f034b6cb8db3e67adfd3d71"
-        frameBorder="0"
-        webkitallowfullscreen="true" mozallowfullscreen="true" allowFullScreen
-        style={{position: 'absolute', 'top': 0, 'left': 0, 'width': '100%', 'height': '100%'}}>
-    </iframe>
+<div
+  style={{
+    position: "relative",
+    paddingBottom: "64.90384615384616%",
+    height: 0,
+  }}
+>
+  <iframe
+    src="https://www.loom.com/embed/164cee809f034b6cb8db3e67adfd3d71"
+    frameBorder="0"
+    webkitallowfullscreen="true"
+    mozallowfullscreen="true"
+    allowFullScreen
+    style={{
+      position: "absolute",
+      top: 0,
+      left: 0,
+      width: "100%",
+      height: "100%",
+    }}
+  ></iframe>
 </div>
 
 Color selection is available on both boards and reports, so you can easily update the segment colors for a report on a board as well. You can learn more in documentation [here](/docs/features/chart-customization#segment-coloring)

--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -267,6 +267,10 @@ $border-radius-lg: 100px;
     border-bottom: 1px solid colors.$base120;
     // max-height: 500px;
 
+    @media (max-width: 600px) {
+      flex-direction: column;
+    }
+
     //title of each changelog entry
     .changelogItemTitle {
       font-size: 28px;
@@ -281,7 +285,8 @@ $border-radius-lg: 100px;
 
     .changelogIndexItemDate {
       width: 190px;
-      margin-right: 34px;
+      margin-right: 36px;
+      margin-bottom: 36px;
     }
 
     //date of changelog entry
@@ -296,6 +301,7 @@ $border-radius-lg: 100px;
 
     .changelogIndexItemBody {
       width: 860px;
+      max-width: 100%;
       color: colors.$grey80;
       font-size: 1.125rem; /* 18px */
       font-weight: 400;

--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -260,25 +260,47 @@ $border-radius-lg: 100px;
 
   //div for changelog entries in the index page
   .changelogIndexItem {
+    display: flex;
+    flex-direction: row;
     margin-top: 40px;
+    max-width: 100%;
+    border-bottom: 1px solid colors.$base120;
     // max-height: 500px;
 
     //title of each changelog entry
     .changelogItemTitle {
-      font-size: 24px;
-      font-weight: 800;
-      line-height: 32px;
+      font-size: 28px;
+      font-weight: 500;
+      line-height: 120%;
       margin-top: 32px;
       // text-shadow: 0px 0px 0.5px black;
+      color: colors.$purple200;
+      font-feature-settings: "salt" on;
+      letter-spacing: -0.28px;
+    }
+
+    .changelogIndexItemDate {
+      width: 190px;
+      margin-right: 34px;
     }
 
     //date of changelog entry
     .changelogDate {
-      opacity: 0.5;
+      color: colors.$grey80;
       font-size: 14px;
-      line-height: 28px;
-      margin-top: 4px;
-      margin-bottom: 2px;
+      font-weight: 500;
+      line-height: 168%; /* 23.52px */
+      letter-spacing: 0.28px;
+      text-wrap: nowrap;
+    }
+
+    .changelogIndexItemBody {
+      width: 860px;
+      color: colors.$grey80;
+      font-size: 1.125rem; /* 18px */
+      font-weight: 400;
+      line-height: 160%;
+      letter-spacing: 0.36px;
     }
 
     //read more button
@@ -287,8 +309,6 @@ $border-radius-lg: 100px;
       text-underline-offset: 2px;
       text-decoration-thickness: from-font;
       color: colors.$purple100;
-      font-size: 1.125rem; /* 18px */
-      line-height: 1.75rem; /* 28px */
     }
   }
 


### PR DESCRIPTION
<img width="1557" alt="Screenshot 2024-10-18 at 3 16 03 PM" src="https://github.com/user-attachments/assets/aa17f9de-817f-427a-86bc-c367e4ca986d">

The new image and video components are being built separately