### PR TITLE
Turn unapproved links into strings

### DIFF
--- a/pages/docs/access-security/single-sign-on.mdx
+++ b/pages/docs/access-security/single-sign-on.mdx
@@ -139,7 +139,7 @@ The SCIM menu in the Access Security tab of the Organization Settings lets you g
 
 Note that only accounts with an **Enterprise plan** have access to SCIM at the moment.
 
-You can find the official SCIM spec subset that Mixpanel implements [here](https://datatracker.ietf.org/doc/html/rfc7644). The base endpoint is https://mixpanel.com/api/app/scim/v2 which you can hit using the SCIM token as an Authentication Bearer token. For instance a GET call on https://mixpanel.com/api/app/scim/v2/Users using the SCIM token will get you a list of all users in your organization. 
+You can find the official SCIM spec subset that Mixpanel implements [here](https://datatracker.ietf.org/doc/html/rfc7644). The base endpoint is `https://mixpanel.com/api/app/scim/v2` which you can hit using the SCIM token as an Authentication Bearer token. For instance a GET call on `https://mixpanel.com/api/app/scim/v2/Users` using the SCIM token will get you a list of all users in your organization. 
 
 <Callout type="info">
   The SCIM endpoint affects only users whose email has a domain in the list of your verified claimed domains.

--- a/pages/docs/privacy.md
+++ b/pages/docs/privacy.md
@@ -33,7 +33,7 @@ Next, you'll need to set the server location to EU when initializing the Mixpane
 - [Flutter](/docs/tracking-methods/sdks/flutter#eu-data-residency)
 
 ## Log in via SSO
-If you want the IdP initiated flow to direct to [eu.mixpanel.com](https://eu.mixpanel.com/), prepend "eu." to your postback URL. For example, [mixpanel.com/security/login/1](https://mixpanel.com/security/login/1) would need to be changed to [eu.mixpanel.com/security/login/1](https://eu.mixpanel.com/security/login/1).
+If you want the IdP initiated flow to direct to [eu.mixpanel.com](https://eu.mixpanel.com/), prepend "eu." to your postback URL. For example, `mixpanel.com/security/login/1` would need to be changed to `eu.mixpanel.com/security/login/1`.
 
 ## Manage Personal Data
 [Mixpanel deletion and retrieval APIs](https://developer.mixpanel.com/reference/gdpr-api) are in place to help Mixpanel implementations meet the requirements outlined by the General Data Protection Regulation (GDPR) legislation.

--- a/redirects/local.txt
+++ b/redirects/local.txt
@@ -43,6 +43,7 @@
 /docs/analysis/reports/insights /docs/reports/insights
 /docs/analysis/reports/retention /docs/reports/retention
 /docs/analysis/users /docs/users
+/docs/best-practices/analytics-strategy/engagement /docs/tracking-best-practices/tracking-plan
 /docs/best-practices/adoption https://mixpanel.com/blog/establish-a-product-analytics-practice/
 /docs/best-practices/analytics-strategy /docs/tutorials/analytics-strategy
 /docs/best-practices/analytics-strategy/overview /docs/best-practices/analytics-strategy


### PR DESCRIPTION
site audit thinks it's broken when in reality it's just not supposed to be a real link