### PR TITLE
Updates docs to be aware of India Data Residency

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -44,6 +44,7 @@
     "dclid",
     "Discoverability",
     "docsearch",
+    "DPDPA",
     "DWCK",
     "expirable",
     "falsey",
@@ -129,8 +130,8 @@
     "wbraid",
     "webkitallowfullscreen",
     "xcworkspace",
-    "yourdomain",
     "XPUT",
+    "yourdomain",
     "yourfullname"
   ]
 }

--- a/pages/docs/data-structure/property-reference/default-properties.mdx
+++ b/pages/docs/data-structure/property-reference/default-properties.mdx
@@ -14,7 +14,7 @@ To disable capturing of geolocation properties (i.e. City, Region, Country) refe
 | $city | City | The city of the event sender parsed from the IP property or the Latitude and Longitude properties. |
 | $region | Region | The region (state or province) of the event sender parsed from the IP property or the Latitude and Longitude properties. |
 | mp_country_code | Country | The country of the event sender parsed from the IP property or the Latitude and Longitude properties. The value is stored as a 2-letter country code in the raw data and parsed into the country name in the UI. |
-| $mp_api_endpoint | API Endpoint | Mixpanel property to record the API endpoint the data was sent to: <br /> **api.mixpanel.com** - default ingestion <br /> **api-eu.mixpanel.com** - EU data ingestion <br /> **api-js.mixpanel.com** - Javascript SDK |
+| $mp_api_endpoint | API Endpoint | Mixpanel property to record the API endpoint the data was sent to: <br /> **api.mixpanel.com** - default ingestion <br /> **api-eu.mixpanel.com** - EU data ingestion <br /> **api-in.mixpanel.com** - India data ingestion <br /> **api-js.mixpanel.com** - Javascript SDK |
 | $import | Import | Internal Mixpanel property set to `true` to indicate that events were sent through [/import API](https://developer.mixpanel.com/reference/import-events). |
 | $mp_api_timestamp_ms | API Timestamp | UTC timestamp in milliseconds when the event was received by our API. |
 | mp_processing_time_ms | Time Processed (UTC) | UTC timestamp in milliseconds when the event was processed by Mixpanel servers. |

--- a/pages/docs/privacy.md
+++ b/pages/docs/privacy.md
@@ -4,36 +4,16 @@ Mixpanel believes in respecting and protecting people’s fundamental online pri
 Visit our [Privacy Hub](https://mixpanel.com/legal/privacy-hub/) to see how we comply with various privacy guidelines.
 
 ## Storing Your Data in the European Union
-By default, Mixpanel stores user data on its US Servers via the Google Cloud Platform.
-However, Mixpanel also provides you with the option to process and store your customers' personal data in Europe via our [EU Data Residency Program](https://mixpanel.com/topics/data-residency-for-mixpanel/).
+Mixpanel provides you with the option to process and store your customers' personal data in Europe via our [EU Data Residency Program](https://mixpanel.com/legal/eu-data-residency/).
 You can enable this by selecting the "EU Data Residency" option when creating a new project and using our EU subdomain during all API calls.
 
-| API | Standard Server | EU Residency Server |
-|-------|-------------------------|--------------------------------|
-| [Ingestion API](https://developer.mixpanel.com/reference/ingestion-api) | `api.mixpanel.com` | `api-eu.mixpanel.com` |
-| [Query API](https://developer.mixpanel.com/reference/query-api) | `mixpanel.com/api` | `eu.mixpanel.com/api` |
-| [Raw Data Export API](https://developer.mixpanel.com/reference/raw-data-export-api) | `data.mixpanel.com/api/2.0/export` | `data-eu.mixpanel.com/api/2.0/export` |
-| [Data Pipelines API](https://developer.mixpanel.com/reference/create-warehouse-pipeline) | `data.mixpanel.com/api/2.0/export` | `data-eu.mixpanel.com/api/2.0/export` |
-| [Lexicon Schemas API](https://developer.mixpanel.com/reference/lexicon-schemas-api) | `mixpanel.com/api/app/projects` | `eu.mixpanel.com/api/app/projects` |
-| [Connectors API](https://developer.mixpanel.com/reference/connectors-api) | `mixpanel.com/api/app/projects` | `eu.mixpanel.com/api/app/projects`|
+See [EU Data Residency](/docs/privacy/eu-residency) for detailed information on how to use EU Data Residency with Mixpanel.
 
-## Using Our SDKs
-Next, you'll need to set the server location to EU when initializing the Mixpanel library. You can find instructions for the required config settings for each SDK below:
+## Storing Your Data in India
+You may process and store your customers' personal data in India via our India Data Residency Program<!-- TODO: link to India DC privacy website page -->.
+Contact your Mixpanel account manager to learn more about enabling India Data Residency for your account.
 
-- [JavaScript](/docs/tracking-methods/sdks/javascript#eu-data-residency)
-- [Objective-C](/docs/tracking-methods/sdks/ios#eu-data-residency)
-- [Swift](/docs/tracking-methods/sdks/ios#eu-data-residency)
-- [Android](/docs/tracking-methods/sdks/android#eu-data-residency)
-- [Python](/docs/tracking-methods/sdks/python#eu-data-residency)
-- [Java](/docs/tracking-methods/sdks/java#eu-data-residencyy)
-- [PHP](/docs/tracking-methods/sdks/php#eu-data-residency)
-- [Ruby](/docs/tracking-methods/sdks/ruby#eu-data-residency)
-- [Node.js](/docs/tracking-methods/sdks/nodejs#eu-data-residency)
-- [React Native](/docs/tracking-methods/sdks/react-native)
-- [Flutter](/docs/tracking-methods/sdks/flutter#eu-data-residency)
-
-## Log in via SSO
-If you want the IdP initiated flow to direct to [eu.mixpanel.com](https://eu.mixpanel.com/), prepend "eu." to your postback URL. For example, `mixpanel.com/security/login/1` would need to be changed to `eu.mixpanel.com/security/login/1`.
+See [India Data Residency](/docs/privacy/in-residency) for detailed information on how to use India Data Residency with Mixpanel.
 
 ## Manage Personal Data
 [Mixpanel deletion and retrieval APIs](https://developer.mixpanel.com/reference/gdpr-api) are in place to help Mixpanel implementations meet the requirements outlined by the General Data Protection Regulation (GDPR) legislation.

--- a/pages/docs/privacy/in-residency.md
+++ b/pages/docs/privacy/in-residency.md
@@ -49,7 +49,7 @@ You can find instructions for the required config settings for each SDK below:
 - [Flutter](/docs/tracking-methods/sdks/flutter#india-data-residency)
 
 ## Log in via SSO
-If you want the IdP initiated flow to direct to [**in.**mixpanel.com](https://in.mixpanel.com/), prepend the "in." subdomain to your postback URL. For example, `mixpanel.com/security/login/1` would need to be changed to `in.mixpanel.com/security/login/1`.
+If you want the IdP initiated flow to direct to [in.mixpanel.com](https://in.mixpanel.com/), prepend the "in." subdomain to your postback URL. For example, `mixpanel.com/security/login/1` would need to be changed to `in.mixpanel.com/security/login/1`.
 
 ## India Residency and Customer Data Platforms (CDPs)
 

--- a/pages/docs/privacy/in-residency.md
+++ b/pages/docs/privacy/in-residency.md
@@ -1,0 +1,56 @@
+# India Data Residency
+
+
+## Overview
+Mixpanel believes in respecting and protecting people’s fundamental online
+privacy and data rights, which is why we've built Mixpanel's analysis tools in
+compliance with industry best practices and global data regulations like India's
+DPDPA.
+
+Visit our [Privacy Hub](https://mixpanel.com/legal/privacy-hub/) to see how we comply with various privacy guidelines.
+
+If you would like access to the India Data Center, reach out to your Mixpanel account manager or [contact us here](https://mixpanel.com/m/india-mixpanel-analytics-for-fintech/).
+
+## Storing Your Data in India
+Mixpanel provides you with the option to process and store your customers'
+personal data in India via our India Data Residency Program. You can enable this
+by selecting the "India Data Residency" option when creating a new project and
+using our India subdomain during all API calls.
+
+**⚠️ Important:** No data will be ingested to your India data residency project unless your SDK is sending data to the India endpoint. Ensure you are using the India endpoint in your SDK configuration.
+
+| API | Standard Server | India Residency Server |
+|-------|-------------------------|--------------------------------|
+| [Ingestion API](https://developer.mixpanel.com/reference/ingestion-api) | `api.mixpanel.com` | `api-in.mixpanel.com` |
+| [Query API](https://developer.mixpanel.com/reference/query-api) | `mixpanel.com/api` | `in.mixpanel.com/api` |
+| [Raw Data Export API](https://developer.mixpanel.com/reference/raw-data-export-api) | `data.mixpanel.com/api/2.0/export` | `data-in.mixpanel.com/api/2.0/export` |
+| [Data Pipelines API](https://developer.mixpanel.com/reference/create-warehouse-pipeline) | `data.mixpanel.com/api/2.0/nessie` | `data-in.mixpanel.com/api/2.0/nessie` |
+| [Lexicon Schemas API](https://developer.mixpanel.com/reference/lexicon-schemas-api) | `mixpanel.com/api/app/projects` | `in.mixpanel.com/api/app/projects` |
+| [Connectors API](https://developer.mixpanel.com/reference/connectors-api) | `mixpanel.com/api/app/projects` | `in.mixpanel.com/api/app/projects`|
+
+You can find where your data is stored under Project Settings > Data Residency for existing projects. Additionally, projects stored in the India will have a URL that starts with 'in.mixpanel.com', whereas projects stored in the US will have a 'mixpanel.com' URL. If the wrong Data Residency location was chosen before implementation, you will need to create a new project with the applicable data storage option and migrate all your existing data. Mixpanel cannot assist with migrating an existing project with the wrong residency location. You can find out more about creating a new project [here](/docs/orgs-and-projects/managing-projects#creating-projects).
+
+
+## Using Our SDKs
+
+Next, you'll need to set the server location to India when initializing the Mixpanel library.
+**This is required for all SDKs.** No data will be ingested to your India data residency project unless your SDK is sending data to the India endpoint.
+You can find instructions for the required config settings for each SDK below:
+
+- [JavaScript](/docs/tracking-methods/sdks/javascript#india-data-residency)
+- [Objective-C](/docs/tracking-methods/sdks/ios#india-data-residency)
+- [Swift](/docs/tracking-methods/sdks/swift#india-data-residency)
+- [Android](/docs/tracking-methods/sdks/android#india-data-residency)
+- [Python](/docs/tracking-methods/sdks/python#india-data-residency)
+- [Java](/docs/tracking-methods/sdks/java#india-data-residency)
+- [Ruby](/docs/tracking-methods/sdks/ruby#india-data-residency)
+- [Node.js](/docs/tracking-methods/sdks/nodejs#india-data-residency)
+- [React Native](/docs/tracking-methods/sdks/react-native#india-data-residency)
+- [Flutter](/docs/tracking-methods/sdks/flutter#india-data-residency)
+
+## Log in via SSO
+If you want the IdP initiated flow to direct to [**in.**mixpanel.com](https://in.mixpanel.com/), prepend the "in." subdomain to your postback URL. For example, `mixpanel.com/security/login/1` would need to be changed to `in.mixpanel.com/security/login/1`.
+
+## India Residency and Customer Data Platforms (CDPs)
+
+If you are coming to use Mixpanel from a CDP, please work with your CDP to ensure they are sending your data to the India endpoint. No data will be ingested to your India data residency project unless your CDP is sending data to the India endpoint.

--- a/pages/docs/tracking-best-practices/debugging.md
+++ b/pages/docs/tracking-best-practices/debugging.md
@@ -65,8 +65,23 @@ If you're using Mixpanel in a web application, you can use your browser's develo
 1. On your website, [enable debug mode](/docs/tracking-methods/sdks/javascript#debug-mode).
 2. Open your browser's developer console and navigate to the Network > Fetch/XHR tab. 
 3. Perform an action that triggers the `mixpanel.track` call.
-4. If your project has US Data Residency, look for a request triggered to `api.mixpanel.com/track`. If your project has [EU Data Residency](/docs/privacy/eu-residency), look for a request triggered to  `api-eu.mixpanel.com/track`. Troubleshoot any error messages.
+4. Look for requests to the Mixpanel API and troubleshoot any error messages.
+    - If your project has US Data Residency, look for a request triggered to `api.mixpanel.com/track`.
+    - If your project has [EU Data Residency](/docs/privacy/eu-residency), look for a request triggered to  `api-eu.mixpanel.com/track`.
+    - If your project has [India Data Residency](/docs/privacy/in-residency), look for a request triggered to  `api-in.mixpanel.com/track`.
 6. If the request is successful, check that the "token" in the data payload matches the token in your [Project Settings](/docs/orgs-and-projects/managing-projects#access-keys). From here, you can then validate that the event was directed to the right project token and using Events, and confirm that the data is arriving correctly in Mixpanel.
+
+### Ensure you are using the API host that matches your project's data residency
+
+If you are using a Mixpanel SDK, you *must* configure it to talk to the correct api host depending on your project's data residency. Refer to the SDK documentation for how to configure the API host.
+
+| Data Residency | API Host |
+|---|---|
+| US Data Residency | `api.mixpanel.com` (default) |
+| [EU Data Residency](/docs/privacy/eu-residency) | `api-eu.mixpanel.com` |
+| [India Data Residency](/docs/privacy/in-residency) | `api-in.mixpanel.com` |
+
+**⚠️ Important:** Projects with India Data Residency *must* configure SDKs with the `api-in.mixpanel.com` host or events will be rejected and will be missing from your project.
 
 ### Customize Flush Interval (Mobile)
 

--- a/pages/docs/tracking-methods/integrations/ad-spend.mdx
+++ b/pages/docs/tracking-methods/integrations/ad-spend.mdx
@@ -198,6 +198,13 @@ const Mixpanel = require('mixpanel');
 
 const MIXPANEL_TOKEN = 'YOUR MIXPANEL TOKEN';
 const MIXPANEL_SECRET = 'YOUR MIXPANEL SECRET';
+// For US Data Residency (default):
+const MIXPANEL_HOST = 'api.mixpanel.com';
+// For EU Data Residency:
+// const MIXPANEL_HOST = 'api-eu.mixpanel.com';
+// For India Data Residency:
+// const MIXPANEL_HOST = 'api-in.mixpanel.com';
+
 const GOOGLE_CLIENT_ID = 'YOUR GOOGLE CREDENTIAL CLIENT ID';
 const GOOGLE_CLIENT_SECRET = 'YOUR GOOGLE CREDENTIAL CLIENT SECRET';
 const GOOGLE_CLIENT_REFRESH_TOKEN = 'YOUR REFRESH TOKEN FOR YOUR GOOGLE CREDENTIAL';
@@ -206,9 +213,7 @@ const GOOGLE_ADS_CUSTOMER_ID = 'YOUR GOOGLE CUSTOMER CLIENT ID WITHOUT HYPHENS';
 
 // End of Configuration
 
-const mixpanel = Mixpanel.init(MIXPANEL_TOKEN, {secret: MIXPANEL_SECRET});
-// Use the below line of init code instead if project in EU residency
-// const mixpanel = Mixpanel.init(MIXPANEL_TOKEN, {host: "api-eu.mixpanel.com", secret: MIXPANEL_SECRET});
+const mixpanel = Mixpanel.init(MIXPANEL_TOKEN, {host: MIXPANEL_HOST, secret: MIXPANEL_SECRET});
 
 const client = new GoogleAdsApi({
     client_id: GOOGLE_CLIENT_ID,
@@ -379,6 +384,12 @@ const Mixpanel = require('mixpanel');
 
 const MIXPANEL_TOKEN = 'YOUR MIXPANEL TOKEN';
 const MIXPANEL_SECRET = 'YOUR MIXPANEL SECRET';
+// For US Data Residency (default):
+const MIXPANEL_HOST = 'api.mixpanel.com';
+// For EU Data Residency:
+// const MIXPANEL_HOST = 'api-eu.mixpanel.com';
+// For India Data Residency:
+// const MIXPANEL_HOST = 'api-in.mixpanel.com';
 const FACEBOOK_TOKEN = 'YOUR FACEBOOK DEVELOPER APP TOKEN';
 const FACEBOOK_AD_ACCOUNT_ID = 123456789012345; // Your Facebook Ad account ID here. e.g. 123456789012345
 const FACEBOOK_AD_API_ACCOUNT = 'act_' + FACEBOOK_AD_ACCOUNT_ID;
@@ -386,13 +397,9 @@ const FACEBOOK_AD_API_ACCOUNT = 'act_' + FACEBOOK_AD_ACCOUNT_ID;
 // End of Configuration
 
 const mixpanel = Mixpanel.init(MIXPANEL_TOKEN, {
+    host: MIXPANEL_HOST,
     secret: MIXPANEL_SECRET
 });
-// Use the init code below instead if project in EU residency
-// const mixpanel = Mixpanel.init(MIXPANEL_TOKEN, {
-//    secret: MIXPANEL_SECRET,
-//    host: "api-eu.mixpanel.com"
-// });
 
 adsSdk.FacebookAdsApi.init(FACEBOOK_TOKEN);
 

--- a/pages/docs/tracking-methods/sdks/android.mdx
+++ b/pages/docs/tracking-methods/sdks/android.mdx
@@ -658,7 +658,7 @@ Route data to Mixpanel's EU servers by adding these meta-data entries under the 
 ```xml Java
 ...
 <application>
-    <!--set request URLs to Mixapnel EU domain-->
+    <!--set request URLs to Mixpanel EU domain-->
     <meta-data android:name="com.mixpanel.android.MPConfig.EventsEndpoint"
            android:value="https://api-eu.mixpanel.com/track?ip=1" />
     <meta-data android:name="com.mixpanel.android.MPConfig.PeopleEndpoint"
@@ -667,6 +667,27 @@ Route data to Mixpanel's EU servers by adding these meta-data entries under the 
            android:value="https://api-eu.mixpanel.com/groups" />
     <meta-data android:name="com.mixpanel.android.MPConfig.DecideEndpoint"
            android:value="https://api-eu.mixpanel.com/decide" />
+    ...
+</application>
+...
+```
+
+### India Data Residency
+
+Route data to Mixpanel's India servers by adding these meta-data entries under the `<application>` tag of your app's `AndroidManifest.xml` to set the URLs of the API requests to our India domain.
+
+```xml Java
+...
+<application>
+    <!--set request URLs to Mixpanel India domain-->
+    <meta-data android:name="com.mixpanel.android.MPConfig.EventsEndpoint"
+           android:value="https://api-in.mixpanel.com/track?ip=1" />
+    <meta-data android:name="com.mixpanel.android.MPConfig.PeopleEndpoint"
+           android:value="https://api-in.mixpanel.com/engage?ip=1" />
+    <meta-data android:name="com.mixpanel.android.MPConfig.GroupsEndpoint"
+           android:value="https://api-in.mixpanel.com/groups" />
+    <meta-data android:name="com.mixpanel.android.MPConfig.DecideEndpoint"
+           android:value="https://api-in.mixpanel.com/decide" />
     ...
 </application>
 ...

--- a/pages/docs/tracking-methods/sdks/flutter.mdx
+++ b/pages/docs/tracking-methods/sdks/flutter.mdx
@@ -541,6 +541,16 @@ Route data to Mixpanel's EU servers by setting the `serverURL` property after in
 mixpanel.setServerURL("https://api-eu.mixpanel.com");
 ```
 
+### India Data Residency
+
+Route data to Mixpanel's India servers by setting the `serverURL` property after initializing the client.
+
+**Example Usage**
+```dart
+// set request URL to Mixpanel's India domain
+mixpanel.setServerURL("https://api-in.mixpanel.com");
+```
+
 ### Disable Geolocation
 
 The Flutter SDK parse the request IP address to generate geolocation properties for events and profiles. To disable geolocation, call [`.setUseIpAddressForGelocation()`](https://mixpanel.github.io/mixpanel-flutter/mixpanel_flutter/Mixpanel/setUseIpAddressForGeolocation.html) with `false`.

--- a/pages/docs/tracking-methods/sdks/ios.mdx
+++ b/pages/docs/tracking-methods/sdks/ios.mdx
@@ -679,6 +679,16 @@ Mixpanel *mixpanel = [Mixpanel sharedInstance];
 self.mixpanel.serverURL = @"https://api-eu.mixpanel.com";
 ```
 
+### India Data Residency
+
+Route data to Mixpanel's India servers by setting the `serverURL` flag after initializing the Mixpanel instance. 
+
+```objc Objective-C
+// set request URL to Mixpanel's India domain
+Mixpanel *mixpanel = [Mixpanel sharedInstance];
+self.mixpanel.serverURL = @"https://api-in.mixpanel.com";
+```
+
 ### Disable Geolocation
 
 The Objective-C SDK parse the request IP address to generate geolocation properties for events and profiles. To disable geolocation, set the [`useIPAddressForGeoLocation`](https://mixpanel.github.io/mixpanel-iphone/Classes/Mixpanel.html#//api/name/useIPAddressForGeoLocation) flag to `NO`.

--- a/pages/docs/tracking-methods/sdks/java.mdx
+++ b/pages/docs/tracking-methods/sdks/java.mdx
@@ -622,6 +622,19 @@ MixpanelAPI mixpanel = new MixpanelAPI( "https://api-eu.mixpanel.com/track",
                                         "https://api-eu.mixpanel.com/groups");
 ```
 
+### India Data Residency
+
+Route data to Mixpanel's India servers by passing in positional arguments into the [`MixpanelAPI`](https://mixpanel.github.io/mixpanel-java/com/mixpanel/mixpanelapi/MixpanelAPI.html) constructor:
+
+**Example Usage**
+
+```java
+// set event, people, and group endpoints to Mixpanel's India domains
+MixpanelAPI mixpanel = new MixpanelAPI( "https://api-in.mixpanel.com/track",
+                                        "https://api-in.mixpanel.com/engage",
+                                        "https://api-in.mixpanel.com/groups");
+```
+
 ### Disable Geolocation
 
 The Java SDK parse the request IP address to generate geolocation properties for events and profiles. You may want to disable them to prevent the unintentional setting of your data's geolocation to the location of your server that is sending the request, or to prevent geolocation data from being tracked entirely.

--- a/pages/docs/tracking-methods/sdks/javascript.mdx
+++ b/pages/docs/tracking-methods/sdks/javascript.mdx
@@ -632,6 +632,7 @@ mixpanel.opt_in_tracking();
 // send "some_other_event"
 mixpanel.track('some_other_event');
 ```
+
 ### EU Data Residency
 Route data to Mixpanel's EU servers by setting a `api_host` configuration when creating the Mixpanel object.
 
@@ -643,6 +644,20 @@ Learn more about [EU Data Residency](/docs/privacy/eu-residency).
 // route requests to Mixpanel's EU servers
 mixpanel.init('YOUR_PROJECT_TOKEN', {
     api_host: 'https://api-eu.mixpanel.com',
+});
+```
+
+### India Data Residency
+Route data to Mixpanel's India servers by setting a `api_host` configuration when creating the Mixpanel object.
+
+Learn more about [India Data Residency](/docs/privacy/in-residency).
+
+**Example Usage**
+```javascript
+// create an instance of the Mixpanel object
+// route requests to Mixpanel's India servers
+mixpanel.init('YOUR_PROJECT_TOKEN', {
+    api_host: 'https://api-in.mixpanel.com',
 });
 ```
 

--- a/pages/docs/tracking-methods/sdks/nodejs.mdx
+++ b/pages/docs/tracking-methods/sdks/nodejs.mdx
@@ -470,7 +470,7 @@ const Mixpanel = require('mixpanel');
 // enable debug logs
 mixpanel.init('YOUR_PROJECT_TOKEN',{
     debug: true
-    });
+});
 ```
 
 ## Privacy-Friendly Tracking
@@ -491,7 +491,22 @@ const Mixpanel = require('mixpanel');
 // set request URLs to Mixpanel's EU domain
 mixpanel.init('YOUR_PROJECT_TOKEN',{
     host: 'api-eu.mixpanel.com'
-    });
+});
+```
+
+### India Data Residency
+
+Route data to Mixpanel's EU servers by setting the [`host`](https://github.com/mixpanel/mixpanel-node/blob/master/lib/mixpanel-node.d.ts#L21) config property during the library initialization.
+
+**Example Usage**
+
+```javascript
+const Mixpanel = require('mixpanel');
+
+// set request URLs to Mixpanel's India domain
+mixpanel.init('YOUR_PROJECT_TOKEN', {
+    host: 'api-in.mixpanel.com'
+});
 ```
 
 ### Disable Geolocation

--- a/pages/docs/tracking-methods/sdks/php.mdx
+++ b/pages/docs/tracking-methods/sdks/php.mdx
@@ -408,6 +408,22 @@ $mp = Mixpanel::getInstance("YOUR_PROJECT_TOKEN", array(
 ?>
 ```
 
+### India Data Residency
+Route data to Mixpanel's India servers by setting a `host` configuration during initialization.
+```php
+<?php
+// import dependencies
+require "vendor/autoload.php";
+
+// create an instance of the Mixpanel class
+$mp = Mixpanel::getInstance("YOUR_PROJECT_TOKEN", array(
+    "host" => "api-in.mixpanel.com" // set host name for api calls to India domain
+    ));
+
+?>
+```
+
+
 ### Disable Geolocation
 
 The PHP SDK parse the request IP address to generate geolocation properties for events and profiles. You may want to disable them to prevent the unintentional setting of your data's geolocation to the location of your server that is sending the request, or to prevent geolocation data from being tracked entirely.

--- a/pages/docs/tracking-methods/sdks/python.mdx
+++ b/pages/docs/tracking-methods/sdks/python.mdx
@@ -442,6 +442,21 @@ mp_eu = Mixpanel(
 )
 ```
 
+### India Data Residency
+
+Route data to Mixpanel's India servers by using a custom `Consumer` with an `api_host` set to the India domain.
+
+**Example Usage**
+```py
+from mixpanel import Mixpanel
+
+# use custom consumer with URLs set to Mixpanel's India domain
+mp_eu = Mixpanel(
+  "YOUR_PROJECT_TOKEN",
+  consumer=mixpanel.Consumer(api_host="api-in.mixpanel.com"),
+)
+```
+
 ### Disable Geolocation
 
 The Python SDK parse the request IP address to generate geolocation properties for events and profiles. You may want to disable them to prevent the unintentional setting of your data's geolocation to the location of your server that is sending the request, or to prevent geolocation data from being tracked entirely.

--- a/pages/docs/tracking-methods/sdks/python.mdx
+++ b/pages/docs/tracking-methods/sdks/python.mdx
@@ -451,7 +451,7 @@ Route data to Mixpanel's India servers by using a custom `Consumer` with an `api
 from mixpanel import Mixpanel
 
 # use custom consumer with URLs set to Mixpanel's India domain
-mp_eu = Mixpanel(
+mp_in = Mixpanel(
   "YOUR_PROJECT_TOKEN",
   consumer=mixpanel.Consumer(api_host="api-in.mixpanel.com"),
 )

--- a/pages/docs/tracking-methods/sdks/react-native.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native.mdx
@@ -649,6 +649,7 @@ mixpanel.optInTracking();
 // send "some_other_event"
 mixpanel.track('some_other_event');
 ```
+
 ### EU Data Residency
 Route data to Mixpanel's EU servers by calling `.setServerURL()` to set the `serverURL` to `https://api-eu.mixpanel.com` after initializing the client.
 
@@ -658,6 +659,17 @@ Learn more about [EU Data Residency](/docs/privacy/eu-residency).
 ```javascript
 // set the Mixpanel instance to send data using Mixpanel's EU domain
 mixpanel.setServerURL('https://api-eu.mixpanel.com');
+```
+
+### India Data Residency
+Route data to Mixpanel's India servers by calling `.setServerURL()` to set the `serverURL` to `https://api-in.mixpanel.com` after initializing the client.
+
+Learn more about [India Data Residency](/docs/privacy/in-residency).
+
+**Example Usage**
+```javascript
+// set the Mixpanel instance to send data using Mixpanel's EU domain
+mixpanel.setServerURL('https://api-in.mixpanel.com');
 ```
 
 ### Disable Geolocation

--- a/pages/docs/tracking-methods/sdks/ruby.mdx
+++ b/pages/docs/tracking-methods/sdks/ruby.mdx
@@ -456,6 +456,27 @@ tracker = Mixpanel::Tracker.new(YOUR_PROJECT_TOKEN) do |type, message|
 end
 ```
 
+### India Data Residency
+
+Route data to Mixpanel's India servers by using a custom [consumer](http://mixpanel.github.io/mixpanel-ruby/Mixpanel/Consumer.html):
+
+**Example Usage**
+
+```ruby
+require 'mixpanel-ruby'
+
+in_consumer = Mixpanel::Consumer.new(
+    'https://api-in.mixpanel.com/track', #set track request URL
+    'https://api-in.mixpanel.com/engage', #set profile request URL
+    'https://api-in.mixpanel.com/groups', #set group request URL
+)
+
+# initialize Mixpanel with your custom consumer
+tracker = Mixpanel::Tracker.new(YOUR_PROJECT_TOKEN) do |type, message|
+    in_consumer.send!(type, message)
+end
+```
+
 ### Disable Geolocation
 
 The Ruby SDK parse the request IP address to generate geolocation properties for events and profiles. You may want to disable them to prevent the unintentional setting of your data's geolocation to the location of your server that is sending the request, or to prevent geolocation data from being tracked entirely.

--- a/pages/docs/tracking-methods/sdks/swift.mdx
+++ b/pages/docs/tracking-methods/sdks/swift.mdx
@@ -617,6 +617,19 @@ Mixpanel.initialize(token: "MIXPANEL_TOKEN")
 Mixpanel.mainInstance().serverURL = "https://api-eu.mixpanel.com"
 ```
 
+### India Data Residency
+
+Route data to Mixpanel's India servers by setting the `serverURL` property after initializing the client. 
+
+**Example Usage**
+```swift Swift
+/// initialize Mixpanel
+Mixpanel.initialize(token: "MIXPANEL_TOKEN")
+
+/// Set request URL to Mixpanel's India domain
+Mixpanel.mainInstance().serverURL = "https://api-in.mixpanel.com"
+```
+
 ### Disable Geolocation
 
 The Swift SDK parse the request IP address to generate geolocation properties for events and profiles. To disable geolocation, set the [`useIPAddressForGeoLocation`](https://mixpanel.github.io/mixpanel-swift/Classes/MixpanelInstance.html#/s:8Mixpanel0A8InstanceC26useIPAddressForGeoLocationSbvp) flag to `false`.

--- a/pages/docs/tracking-methods/sdks/unity.mdx
+++ b/pages/docs/tracking-methods/sdks/unity.mdx
@@ -399,6 +399,10 @@ Mixpanel.OptInTracking();
 
 Route data to Mixpanel's EU servers by setting the `API Host Address` to `https://api-eu.mixpanel.com/` when configuring the library under the unity project settings menu for Mixpanel (Edit -> Project Settings -> Mixpanel).
 
+### India Data Residency
+
+Route data to Mixpanel's EU servers by setting the `API Host Address` to `https://api-in.mixpanel.com/` when configuring the library under the unity project settings menu for Mixpanel (Edit -> Project Settings -> Mixpanel).
+
 ## Release History
 
 [See all releases.](https://github.com/mixpanel/mixpanel-unity/releases)


### PR DESCRIPTION
Updates docs with addition of India-specific endpoints, updates to the privacy documentation, and instructions for configuring SDKs for India Data Residency.

- make cspell aware of DPDPA
- Updates random parts of docs that reference api-eu to also reference api-in
- streamline privacy page to be aware of both india and EU
- Adds /docs/privacy/in-residency with detailed instructions on how to use India DC
- Updates all SDKs to be aware of India DC
- Updates debugging page with india instructions