### PR TITLE
[Changelog] add subscribe to product updates modal and functionality

### DIFF
--- a/components/SubscribeButtonWithModal/SubscribeButtonWithModal.tsx
+++ b/components/SubscribeButtonWithModal/SubscribeButtonWithModal.tsx
@@ -1,8 +1,10 @@
 import { useState, MouseEvent } from "react";
-import { Checkbox, Dialog } from "@headlessui/react";
+import { Dialog } from "@headlessui/react";
+// https://www.tailwind-variants.org/docs
+import { tv } from "tailwind-variants";
+
 import { track } from "../../utils/tracking";
 import { APIMethods, BaseAPI, HeaderContentType } from "../../utils/client";
-//import { APIMethods, BaseAPI, HeaderContentType } from "@src/utils/client";
 
 // default, focus, error, success
 const enum SubscribeInputState {
@@ -27,6 +29,8 @@ export default function SubscribeButtonWithModal() {
   const [subscribeInputState, setSubscribeInputState] = useState(
     SubscribeInputState.Default
   );
+  const submitDisabled =
+    subscribeInputState === SubscribeInputState.Error || !agreedToTerms;
 
   const validateEmail = (): string => {
     let errorMsg = ``;
@@ -71,7 +75,6 @@ export default function SubscribeButtonWithModal() {
         track(`[DOCS] Subscribed to Product Updates`, {});
         setSubscribeInputState(SubscribeInputState.Success);
         setError(``);
-        setIsOpen(false);
       } catch (e) {
         // send to rollbar.
         /* track(
@@ -89,10 +92,24 @@ export default function SubscribeButtonWithModal() {
     }
   };
 
+  const submitButton = tv({
+    base: "nx-px-5 nx-py-3 nx-my-4 nx-drop-shadow-sm nx-bg-gradient-to-t nx-from-purple100 nx-to-purple50 nx-rounded-full nx-text-white nx-font-medium",
+    variants: {
+      disabled: {
+        true: "",
+        false: "",
+      },
+    },
+  });
+
   return (
     <div>
-      <button type="button" onClick={() => setIsOpen(true)}>
-        SUBSCRIBE
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="nx-px-5 nx-py-3 nx-my-4 nx-drop-shadow-sm nx-bg-gradient-to-t nx-from-purple100 nx-to-purple50 nx-rounded-full nx-text-white nx-font-medium"
+      >
+        Subscribe
       </button>
       <Dialog
         open={isOpen}
@@ -113,7 +130,7 @@ export default function SubscribeButtonWithModal() {
                   Company Email
                 </label>
                 <input
-                  className="nx-rounded-full nx-px-6 nx-py-3.5"
+                  className="nx-rounded-full nx-px-6 nx-py-3.5 nx-outline-purple100"
                   aria-label="Subscribe"
                   disabled={subscribeInputState === SubscribeInputState.Success}
                   value={
@@ -132,8 +149,16 @@ export default function SubscribeButtonWithModal() {
                   }}
                 />
               </div>
-              <div>
+              {error ? (
+                <div className="nx-text-xs nx-text-lava140 nx-ml-6 nx-mt-1">
+                  <p>{error}</p>
+                </div>
+              ) : (
+                <></>
+              )}
+              <div className="nx-flex nx-mt-4">
                 <input
+                  className="nx-mr-2"
                   type="checkbox"
                   aria-label="Subscribe"
                   disabled={subscribeInputState === SubscribeInputState.Success}
@@ -143,7 +168,7 @@ export default function SubscribeButtonWithModal() {
                     validateEmail();
                   }}
                 />
-                <span>
+                <span className="nx-text-grey80 nx-text-xs nx-leading-normal">
                   I agree to receive product update emails about Mixpanel
                   products pursuant to the{" "}
                   <a
@@ -156,19 +181,11 @@ export default function SubscribeButtonWithModal() {
                   . I understand that I can opt-out at any time.
                 </span>
               </div>
-              {error ? (
-                <div>
-                  <p>{error}</p>
-                </div>
-              ) : (
-                <></>
-              )}
+
               <button
                 onClick={handleSubmit}
-                disabled={
-                  subscribeInputState === SubscribeInputState.Error ||
-                  !agreedToTerms
-                }
+                disabled={submitDisabled}
+                className={submitButton({ disabled: submitDisabled })}
               >
                 Subscribe
               </button>

--- a/components/SubscribeButtonWithModal/SubscribeButtonWithModal.tsx
+++ b/components/SubscribeButtonWithModal/SubscribeButtonWithModal.tsx
@@ -1,0 +1,181 @@
+import { useState, MouseEvent } from "react";
+import { Checkbox, Dialog } from "@headlessui/react";
+import { track } from "../../utils/tracking";
+import { APIMethods, BaseAPI, HeaderContentType } from "../../utils/client";
+//import { APIMethods, BaseAPI, HeaderContentType } from "@src/utils/client";
+
+// default, focus, error, success
+const enum SubscribeInputState {
+  Default = `default`,
+  Focus = `focus`,
+  Error = `error`,
+  Success = `success`,
+}
+
+// From /iron/common/util/string.ts
+// See https://stackoverflow.com/questions/46155/how-can-you-validate-an-email-address-in-javascript
+export const IRON_EMAIL_REGEX =
+  /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i;
+
+const GTMFormEndpoint = `https://mixpanel.com/api/app/form/gtm_form`; // prod domain for testing even in staging
+
+export default function SubscribeButtonWithModal() {
+  const [email, setEmail] = useState(``);
+  const [agreedToTerms, setAgreedToTerms] = useState(false);
+  const [error, setError] = useState(``);
+  const [isOpen, setIsOpen] = useState(false);
+  const [subscribeInputState, setSubscribeInputState] = useState(
+    SubscribeInputState.Default
+  );
+
+  const validateEmail = (): string => {
+    let errorMsg = ``;
+    if (!email) {
+      errorMsg = `Email address is required.`;
+    } else if (!IRON_EMAIL_REGEX.test(email)) {
+      errorMsg = `Please enter a valid email address`;
+    }
+    if (errorMsg) {
+      setSubscribeInputState(SubscribeInputState.Error);
+      setError(errorMsg);
+    } else {
+      setSubscribeInputState(SubscribeInputState.Default);
+      setError(``);
+    }
+    return errorMsg;
+  };
+
+  const handleSubmit = async (e: MouseEvent) => {
+    e.preventDefault();
+    if (!validateEmail()) {
+      try {
+        await BaseAPI({
+          url: GTMFormEndpoint,
+          method: APIMethods.POST,
+          headerContentType: HeaderContentType.JSON,
+          body: {
+            form_name: `Product Updates Subscription`,
+            subscribe_topics: [`Product Newsletter Emails`],
+            email_address: email,
+            //TODO: Follow Up with Legal/Design
+            agreed_on_privacy_terms: true,
+            email_preference_opt_in_info: true,
+            distinct_id:
+              // @ts-ignore
+              mixpanel?.get_property !== undefined
+                ? // @ts-ignore
+                  mixpanel?.get_property(`distinct_id`)
+                : ``,
+          },
+        });
+        track(`[DOCS] Subscribed to Product Updates`, {});
+        setSubscribeInputState(SubscribeInputState.Success);
+        setError(``);
+        setIsOpen(false);
+      } catch (e) {
+        // send to rollbar.
+        /* track(
+          BlogEvents.SubscribeRequestFailed,
+          {
+            message:
+              `failed to succesfully submit Subscribe request` +
+              (e instanceof Error ? e.message : JSON.stringify(e)),
+          },
+          true,
+          RollbarType.Error
+        ); */
+        setError(`Failed to subscribe. Please try again.`);
+      }
+    }
+  };
+
+  return (
+    <div>
+      <button type="button" onClick={() => setIsOpen(true)}>
+        SUBSCRIBE
+      </button>
+      <Dialog
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        className="relative z-50"
+      >
+        <div className="nx-fixed nx-inset-0 nx-flex nx-w-screen nx-items-center nx-justify-center nx-p-4 nx-bg-black nx-bg-opacity-80 nx-z-20">
+          <Dialog.Panel className="nx-w-full nx-max-w-2xl ">
+            <div className="changelogSubscribeModalInner nx-bg-base80 nx-p-8 nx-rounded-3xl">
+              <div className="nx-text-3xl nx-font-medium nx-text-center nx-mb-4">
+                Subscribe to product updates
+              </div>
+              <div className="nx-text-lg nx-text-center nx-mb-6">
+                Sign up to stay up-to-date on our newest releases.
+              </div>
+              <div className="nx-flex nx-flex-col">
+                <label className="nx-font-medium nx-ml-6 nx-mb-1">
+                  Company Email
+                </label>
+                <input
+                  className="nx-rounded-full nx-px-6 nx-py-3.5"
+                  aria-label="Subscribe"
+                  disabled={subscribeInputState === SubscribeInputState.Success}
+                  value={
+                    subscribeInputState === SubscribeInputState.Success
+                      ? `Thanks for subscribing!`
+                      : email
+                  }
+                  onChange={(evt) => setEmail(evt.target.value)}
+                  placeholder="you@email.com"
+                  onFocus={(_e) =>
+                    setSubscribeInputState(SubscribeInputState.Focus)
+                  }
+                  onBlur={(_e) => {
+                    setSubscribeInputState(SubscribeInputState.Default);
+                    validateEmail();
+                  }}
+                />
+              </div>
+              <div>
+                <input
+                  type="checkbox"
+                  aria-label="Subscribe"
+                  disabled={subscribeInputState === SubscribeInputState.Success}
+                  aria-selected={agreedToTerms}
+                  onChange={(_e) => setAgreedToTerms((agreed) => !agreed)}
+                  onBlur={(_e) => {
+                    validateEmail();
+                  }}
+                />
+                <span>
+                  I agree to receive product update emails about Mixpanel
+                  products pursuant to the{" "}
+                  <a
+                    href="https://www.mixpanel.com/legal/privacy-policy"
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    Privacy Statement
+                  </a>
+                  . I understand that I can opt-out at any time.
+                </span>
+              </div>
+              {error ? (
+                <div>
+                  <p>{error}</p>
+                </div>
+              ) : (
+                <></>
+              )}
+              <button
+                onClick={handleSubmit}
+                disabled={
+                  subscribeInputState === SubscribeInputState.Error ||
+                  !agreedToTerms
+                }
+              >
+                Subscribe
+              </button>
+            </div>
+          </Dialog.Panel>
+        </div>
+      </Dialog>
+    </div>
+  );
+}

--- a/components/SubscribeButtonWithModal/SubscribeButtonWithModal.tsx
+++ b/components/SubscribeButtonWithModal/SubscribeButtonWithModal.tsx
@@ -5,6 +5,7 @@ import { tv } from "tailwind-variants";
 
 import { track } from "../../utils/tracking";
 import { APIMethods, BaseAPI, HeaderContentType } from "../../utils/client";
+import { APITrackingEvents, trackResponse } from "../../utils/tracking-wrapper";
 
 // default, focus, error, success
 const enum SubscribeInputState {
@@ -77,16 +78,16 @@ export default function SubscribeButtonWithModal() {
         setError(``);
       } catch (e) {
         // send to rollbar.
-        /* track(
-          BlogEvents.SubscribeRequestFailed,
-          {
-            message:
+        trackResponse({
+          APIContext: {
+            event: APITrackingEvents.Error,
+            response:
               `failed to succesfully submit Subscribe request` +
               (e instanceof Error ? e.message : JSON.stringify(e)),
           },
-          true,
-          RollbarType.Error
-        ); */
+          eventContext: `[DOCS] Subscribe to Product Updates Failed}`,
+          sendToRollbar: true,
+        });
         setError(`Failed to subscribe. Please try again.`);
       }
     }

--- a/components/SubscribeButtonWithModal/index.ts
+++ b/components/SubscribeButtonWithModal/index.ts
@@ -1,0 +1,1 @@
+export { default as SubscribeButtonWithModal } from "./SubscribeButtonWithModal";

--- a/pages/changelogs.mdx
+++ b/pages/changelogs.mdx
@@ -1,3 +1,5 @@
+import { SubscribeButtonWithModal } from "../components/SubscribeButtonWithModal";
+
 <div class="changelogMainContainerWrapper">
 <div class="changelogMainContainer">
 
@@ -9,9 +11,8 @@ md:text-5xl mt-8 pb-6"
     >
       Changelog
     </h1>
-    <span>
-      <a>Subscribe to our newsletter</a> to get product updates in your inbox.
-    </span>
+    <span>Get all the latest updates in your inbox.</span>
+    <SubscribeButtonWithModal />
   </div>
   <img
     class="changelogHeaderImg"

--- a/utils/client.ts
+++ b/utils/client.ts
@@ -1,0 +1,71 @@
+// Taken from /marketing-site/src/utils/client.ts
+export enum APIMethods {
+    POST = `POST`,
+    GET = `GET`,
+}
+
+// Certain POST Django endpoints in the Mixpanel app appear to require distinct Content-Types and body formats.
+export enum HeaderContentType {
+    JSON = `application/json`,
+    FormUrlEncoded = `application/x-www-form-urlencoded`,
+}
+
+interface APIRequestProps {
+    token?: string;
+    url: string;
+    method?: APIMethods;
+    body?: any;
+    headerContentType?: HeaderContentType;
+}
+
+export type SuccessResponse<ResultsType> = {
+    status: `ok`;
+    results: ResultsType;
+};
+
+export type ErrorResponse = {
+    status: `error`;
+    error: string;
+    type?: string;
+};
+
+export type ApiResponse<ResultsType> =
+    | ErrorResponse
+    | SuccessResponse<ResultsType>;
+
+type Obj<ValueT = any> = Record<string, ValueT>;
+export function objToQueryString(params: Obj): string {
+    return Object.keys(params)
+        .map((k) => [k, encodeURIComponent(params[k])].join(`=`))
+        .join(`&`);
+}
+
+async function BaseAPI({
+    token,
+    url,
+    method = APIMethods.GET,
+    headerContentType = HeaderContentType.JSON,
+    body,
+}: APIRequestProps) {
+    const preparedBody =
+        headerContentType === HeaderContentType.JSON
+            ? JSON.stringify(body)
+            : objToQueryString(body);
+
+    const OPTIONS = {
+        method: method,
+        headers: {
+            "Content-Type": headerContentType,
+            ...(token && { Authorization: `Bearer ${token}` }),
+        },
+        ...([body] && { body: preparedBody }),
+    };
+
+    const response = await fetch(url, OPTIONS).then((response: any) =>
+        response.json(),
+    );
+
+    return response;
+}
+
+export { BaseAPI };

--- a/utils/error-reporting.ts
+++ b/utils/error-reporting.ts
@@ -1,0 +1,122 @@
+// * Usage: Sends an event with stack trace (if available) to Rollbar
+// * For API responses (usually just errors), please use
+// * `trackResponse({ sendToRollbar: true })` to send
+// * sync'd items to Mixpanel + Rollbar
+
+export function isBrowserEnv(): boolean {
+    return typeof window !== `undefined`;
+}
+
+enum LogLevel {
+    ERROR = `error`,
+    WARN = `warn`,
+    INFO = `info`,
+}
+
+/** wrap a string in Error to generate a trace for logging. */
+function maybeWrapAsError(arg: string | Error) {
+    if (!(arg instanceof Error)) {
+        return new Error(arg);
+    } else {
+        return arg;
+    }
+}
+
+interface LogMessage {
+    rollbarLink?: string;
+    stack?: string;
+    message: string;
+}
+
+const logList: { [k in LogLevel]: LogMessage[] } = {
+    error: [],
+    info: [],
+    warn: [],
+};
+
+export const errorReportingUtils = {
+    getConsoleLogs,
+};
+
+function getConsoleLogs(): { [k in LogLevel]: LogMessage[] } {
+    return logList;
+}
+
+/**
+ * Reports some kind of message to console and Rollbar (if defined).
+ *
+ * Raw strings will be wrapped in an Error to preserve
+ * a stack trace.
+ *
+ * The rollbar client's log methods accept arguments in any order, see
+ * https://docs.rollbar.com/docs/rollbarjs-configuration-reference#rollbarlog
+ *
+ * @param logLevel - error, info, or warn type
+ * @param error - the message to display
+ * @param info - extra parameters to log, or a nice message
+ * @param rest - any additional params for rollbar
+ */
+function reportToConsoleAndRollbar(
+    logLevel: LogLevel,
+    message: string | Error,
+    info?: any,
+    ...rest: any[]
+) {
+    const maybeError = maybeWrapAsError(message);
+    const baseMessage = message instanceof Error ? message.message : message;
+    const prettyMessage = `${baseMessage}${info ? `\n` + JSON.stringify(info) : ``}`;
+    const logMsg: LogMessage = {
+        message: prettyMessage,
+        stack: maybeError.stack,
+    };
+    // eslint-disable-next-line no-console
+    console[logLevel](message, info, ...rest);
+
+    // @ts-ignore
+    if (isBrowserEnv() && window[`Rollbar`]) {
+        // @ts-ignore
+        const rollbarResp = window[`Rollbar`]?.[logLevel]?.(
+            maybeError,
+            info,
+            ...rest,
+        );
+        if (rollbarResp?.uuid) {
+            logMsg.rollbarLink = `https://rollbar.com/item/uuid/?uuid=${rollbarResp.uuid}`;
+        }
+    }
+    logList[logLevel].push(logMsg);
+}
+
+// For capturing stray error window error events that we don't want to log to Rollbar
+export function logTopLevelError(ev: ErrorEvent) {
+    // TODO some shared const list for this?
+    if (
+        [
+            `ResizeObserver loop limit exceeded`,
+            `ResizeObserver loop completed with undelivered notifications.`,
+        ].includes(ev.message)
+    ) {
+        return;
+    }
+    const logMsg: LogMessage = {
+        message: `${ev.message} (${ev.filename}: ${ev.lineno})`,
+    };
+    logList.error.push(logMsg);
+}
+
+function createReporterFunc(logLevel: LogLevel) {
+    return function (message: string | Error, info?: any, ...rest: any[]) {
+        reportToConsoleAndRollbar(logLevel, message, info, ...rest);
+    };
+}
+
+/**
+ * @example
+ * reporter.info(`some message to report`);
+ * reporter.error(new Error(`everything is on fire`));
+ */
+export const reporter = {
+    error: createReporterFunc(LogLevel.ERROR),
+    warn: createReporterFunc(LogLevel.WARN),
+    info: createReporterFunc(LogLevel.INFO),
+};

--- a/utils/tracking-wrapper.ts
+++ b/utils/tracking-wrapper.ts
@@ -1,0 +1,143 @@
+// * Usage: Sends an event with API response info to Mixpanel
+// * and Rollbar (if `sendToRollbar` is true)
+
+/**
+ * @example
+ * ```
+ * trackResponse({
+ *      APIContext: {
+ *          event: APITrackingEvents.Error,
+ *      },
+ *      eventContext: `${EVENT_CONTEXT} > fun()`,
+ *      sendToRollbar: true,
+ *      ...values,
+ * });
+ * ```
+ */
+
+import { reporter } from "./error-reporting";
+import { track } from "./tracking";
+
+// Defines tracked events in docs
+export const enum DocsEvents {
+    // COMMON EVENTS
+    CtaClicked = `Cta Clicked`,
+    TryTemplateClick = `Try Feature Launch Template Click`,
+    /* clicked on get live demo */
+    GetLiveDemoClick = `Get Live Demo Click`,
+    /* clicked on explore demo dataset link that links to mixpanel demo dataset project */
+    ExploreDemoLinkClick = `Explore Demo Dataset Click`,
+    HeaderClick = `Clicked on the Nav Header`,
+
+    // Changelog Events
+    SubscribedProductUpdates = `[DOCS] Subscribed to Product Updates`
+}
+
+// Defines tracked properties in docs
+export const enum DocsEventsProperties {
+    // COMMON PROPERTIES
+    Team = `Team`,
+    NavItem = `Nav Item`,
+    ComponentName = `Component`,
+    CtaText = `Cta Text`,
+
+    // MARKETING FORM
+    // email used to submit marketing related form
+    EmailFromMarketingForm = `Email from Marketing Form`,
+}
+
+export const BENCHMARKS_SOURCE = `Marketing Landing Page`;
+export const MARKETING_LOGIN_PREFIX = `[Marketing Login]`;
+
+// Defines tracked events specific to APIs
+export enum APITrackingEvents {
+    Error = `API Response Error`,
+    Success = `API Response Success`,
+}
+
+export enum ResponseType {
+    Xhr = `XHR`,
+}
+
+type TrackResponseProps = {
+    APIContext: {
+        event: APITrackingEvents;
+        type?: ResponseType;
+        response?: string;
+        requestUrl?: string;
+    };
+    eventContext: string; // Eg: be specific about component or function
+    accountId?: number;
+    formId?: string;
+    sendToRollbar?: boolean;
+    // Whatever else
+    [key: string]: any;
+};
+
+type EventProperties = {
+    [key: string]: any;
+};
+
+export const enum RollbarType {
+    Info = `info`,
+    Error = `error`,
+}
+
+function mixpanelDefined() {
+    return typeof mixpanel !== `undefined`;
+}
+
+export function trackEvent(
+    eventName: DocsEvents,
+    properties: EventProperties,
+    sendToRollbar = false,
+    rollbarType = RollbarType.Info,
+) {
+    if (mixpanelDefined()) {
+        properties[DocsEventsProperties.Team] = `Interactive`;
+        mixpanel.track(`${eventName}`, properties);
+    }
+
+    if (sendToRollbar) {
+        if (rollbarType === RollbarType.Error) {
+            reporter.error(eventName, { ...properties });
+        } else {
+            reporter.info(eventName, { ...properties });
+        }
+    }
+}
+
+export function trackResponse({
+    APIContext,
+    eventContext,
+    ...rest
+}: TrackResponseProps) {
+    const API_LOG = {
+        ...(APIContext.type && { [`Type`]: APIContext.type }),
+        ...(APIContext.response && { [`Response`]: APIContext.response }),
+        ...(APIContext.requestUrl && {
+            [`Request URL`]: APIContext.requestUrl,
+        }),
+    };
+    track(APIContext.event, {
+        ...API_LOG,
+        [`Event context`]: eventContext,
+        [`Team`]: `Interactive`,
+
+        ...(rest.accountId && { [`Account ID`]: rest.accountId }),
+        ...(rest.formId && { [`Form ID`]: rest.formId }),
+        ...(rest.email_address && {
+            [DocsEventsProperties.EmailFromMarketingForm]:
+                rest.email_address,
+        }),
+        ...rest,
+    });
+
+    const ROLLBAR_MSG = `Event: ${APIContext.event}, Context: ${eventContext}`;
+
+    if (rest.sendToRollbar) {
+        APIContext.event === APITrackingEvents.Error
+            ? reporter.error(ROLLBAR_MSG, { API_LOG, ...rest })
+            : reporter.info(ROLLBAR_MSG, { API_LOG, ...rest });
+    }
+}


### PR DESCRIPTION
Adds a modal with subscription form similar to what is on the What's New Page and sends to the same gtm_form but gets a 400 error because the preview links for docs are not on a mixpanel domain

<img width="1296" alt="Screenshot 2024-10-30 at 2 49 16 PM" src="https://github.com/user-attachments/assets/730a1ab6-68d0-4cd4-b73f-bc06a4f1bdca">
