### PR TITLE
Update javascript.mdx - Broken anchor links

### DIFF
--- a/pages/docs/tracking-methods/sdks/javascript.mdx
+++ b/pages/docs/tracking-methods/sdks/javascript.mdx
@@ -169,7 +169,7 @@ In addition to UTM parameters, Mixpanel will also add any advertising click IDs 
 Learn more about [UTM tracking](/docs/tracking-best-practices/traffic-attribution#web-attribution).
 
 <Callout type="info">
-    Note: UTM parameters are by default persisted as [Super Properties](/docs/tracking-methods/sdks/javascript#super-properties). To disable this UTM persistence, use the SDK initialization option `{stop_utm_persistence: true}` (refer to our [Release Notes](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.52.0) in GitHub).
+    Note: UTM parameters are by default persisted as [Super Properties](/docs/tracking-methods/sdks/javascript#setting-super-properties). To disable this UTM persistence, use the SDK initialization option `{stop_utm_persistence: true}` (refer to our [Release Notes](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.52.0) in GitHub).
 </Callout>
 
 #### Other Tracking Methods
@@ -705,7 +705,7 @@ mixpanel.init('YOUR_PROJECT_TOKEN', {
 If you configure your instance to send data over HTTP (instead of HTTPS) but set `secure_cookie: true`, then your cookie data will not sent to the server.
 
 #### Hosted Subdomains
-By default, Mixpanel cookie works across subdomain, keeping Mixpanel's Distinct ID and [Super Properties](/docs/tracking-methods/sdks/javascript#super-properties) consistent across your sub-domains. For hosted subdomains (see [complete list of affected domains](https://publicsuffix.org/list/effective_tld_names.dat)) that don't allow cross-subdomain cookies, disable cross-subdomain cookie by setting the  `cross_subdomain_cookie` configuration option to `false`. Alternatively, you can also use a `CNAME` to change from `yourdomain.hostapp.com` to `yourdomain.com`.
+By default, Mixpanel cookie works across subdomain, keeping Mixpanel's Distinct ID and [Super Properties](/docs/tracking-methods/sdks/javascript#setting-super-properties) consistent across your sub-domains. For hosted subdomains (see [complete list of affected domains](https://publicsuffix.org/list/effective_tld_names.dat)) that don't allow cross-subdomain cookies, disable cross-subdomain cookie by setting the  `cross_subdomain_cookie` configuration option to `false`. Alternatively, you can also use a `CNAME` to change from `yourdomain.hostapp.com` to `yourdomain.com`.
 
 **Example Usage**
 ```javascript


### PR DESCRIPTION
Anchor link to Setting Super Properties section was outdated. was "super-properties" and should be "setting-super-properties"