### PR TITLE
[Changelog] Header img css update

### DIFF
--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -279,11 +279,15 @@ $border-radius-lg: 100px;
   }
 
   .changelogHeaderImg {
-    width: 50%;
+    width: 100%;
     max-width: 560px;
     margin-bottom: auto;
     position: relative;
     right: -64px;
+
+    @media (max-width: 965px) {
+      width: 50%
+    }
 
     @media (max-width: 700px) {
       display: none;

--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -279,10 +279,9 @@ $border-radius-lg: 100px;
   }
 
   .changelogHeaderImg {
-    max-width: 560px;
     width: 50%;
-    border-radius: 16px;
-    margin-bottom: 16px;
+    max-width: 560px;
+    margin-bottom: auto;
     position: relative;
     right: -64px;
 


### PR DESCRIPTION
Align image to the bottom of the navigation (margin-bottom: auto).
Start scaling at 950px. This is where the image starts to get cropped.

https://www.notion.so/mxpnl/Changelog-QA-135e0ba9256280e3ba7cf74849da6e42?p=137e0ba9256280e8a7c9d0cd4d84fb4c&pm=s