### PR TITLE
[Changelogs] update loom video urls to include title and share links in video modal

### DIFF
--- a/pages/changelogs/2024-05-09-column-charts.mdx
+++ b/pages/changelogs/2024-05-09-column-charts.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-05-09T18:59:02.165Z"
 updatedAt: "2024-05-09T18:59:02.165Z"
 date: "2024-05-09"
 thumbnail: "/changelog/analysis-hero.webp"
-video: "https://www.loom.com/embed/cf7bfc28090d4e14864ee7e7d4cacc29"
+video: "https://www.loom.com/embed/cf7bfc28090d4e14864ee7e7d4cacc29?sid=9d330902-e93e-4eb9-b4fa-3518fd815a32"
 description: "You can now view your time series as a column or stacked column chart in Insights report."
 isAnnouncement: true
 ---
@@ -27,4 +27,4 @@ You can now view your time series as a column or stacked column chart in Insight
 
 Column charts give you another way to visualize your data. Column charts tend to be better when visualizing data over shorter time frames.
 
-<VideoButtonWithModal src="https://www.loom.com/embed/cf7bfc28090d4e14864ee7e7d4cacc29" />
+<VideoButtonWithModal src="https://www.loom.com/embed/cf7bfc28090d4e14864ee7e7d4cacc29?sid=9d330902-e93e-4eb9-b4fa-3518fd815a32" />

--- a/pages/changelogs/2024-06-18-mirror-warehouse.mdx
+++ b/pages/changelogs/2024-06-18-mirror-warehouse.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-06-18T17:39:02.165Z"
 updatedAt: "2024-06-18T17:39:02.165Z"
 date: "2024-06-18"
 thumbnail: "/changelog/mirror-mode-hero.webp"
-video: "https://www.loom.com/embed/e1a1d6539b2146be9b22190be632b9af"
+video: "https://www.loom.com/embed/e1a1d6539b2146be9b22190be632b9af?sid=27106814-485b-44d6-bc27-8684011294d8"
 description: "Mirror is a new mode on Warehouse Connectors that keeps Mixpanel in perfect sync with your warehouse. Any time data is modified in your underlying warehouse table, that change is automatically reflected in Mixpanel through change data capture (CDC). You can iteratively implement, rename or remove columns, or reconcile transactions in your warehouse without any worry of data divergence in Mixpanel. This sync enables accurate analysis for all data types, including business data that changes often like purchases."
 isAnnouncement: true
 ---
@@ -20,4 +20,4 @@ Mirror is a new mode on Warehouse Connectors that keeps Mixpanel in perfect sync
 
 Supported for BigQuery and Snowflake today. Contact your account team to get access.
 
-<VideoButtonWithModal src="https://www.loom.com/embed/e1a1d6539b2146be9b22190be632b9af" />
+<VideoButtonWithModal src="https://www.loom.com/embed/e1a1d6539b2146be9b22190be632b9af?sid=27106814-485b-44d6-bc27-8684011294d8" />

--- a/pages/changelogs/2024-06-27-axis-customization.mdx
+++ b/pages/changelogs/2024-06-27-axis-customization.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-06-27T16:50:45.397Z"
 updatedAt: "2024-06-27T16:50:45.397Z"
 date: "2024-06-27"
 thumbnail: "/changelog/axis-customization.png"
-video: "https://www.loom.com/share/70a6b9f7a5104f9481dcde54f1c292be"
+video: "https://www.loom.com/share/70a6b9f7a5104f9481dcde54f1c292be?sid=e8706d41-320d-45ea-afb9-3f579438175c"
 description: "You can now customize the axes of your charts. Using this, you can build better dashboards and tell the story you want more easily. Any changes you make can be saved and will be reflected on the dashboard. To access these new options, go to the 'Chart' tab of the query builder."
 ---
 
@@ -27,4 +27,4 @@ You'll be able to:
 
 You can learn more in documentation [here](/docs/features/chart-customization#axis-customization)
 
-<VideoButtonWithModal src="https://www.loom.com/embed/70a6b9f7a5104f9481dcde54f1c292be" />
+<VideoButtonWithModal src="https://www.loom.com/embed/70a6b9f7a5104f9481dcde54f1c292be?sid=e8706d41-320d-45ea-afb9-3f579438175c" />

--- a/pages/changelogs/2024-06-27-color-themes.mdx
+++ b/pages/changelogs/2024-06-27-color-themes.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-06-27T17:50:45.397Z"
 updatedAt: "2024-06-27T17:50:45.397Z"
 date: "2024-06-27"
 thumbnail: "/changelog/color-themes.png"
-video: "https://www.loom.com/share/11ccbc78c66e42af8405d81ffa7bdea9"
+video: "https://www.loom.com/share/11ccbc78c66e42af8405d81ffa7bdea9?sid=9391ca32-b30c-41af-b8ae-be4112c138d7"
 description: "You can now set the color theme of your charts in Mixpanel. We have a few preset themes for you, but you can also create and save your own theme. You use a different theme for every report, and even have a dashboard with reports using different themes. You'll also be able to set a project wide default for color themes."
 ---
 
@@ -20,4 +20,4 @@ You can now set the color theme of your charts in Mixpanel. We have a few preset
 
 You can learn more in documentation [here](/docs/features/chart-customization#theme-customization)
 
-<VideoButtonWithModal src="https://www.loom.com/embed/11ccbc78c66e42af8405d81ffa7bdea9" />
+<VideoButtonWithModal src="https://www.loom.com/embed/11ccbc78c66e42af8405d81ffa7bdea9?sid=9391ca32-b30c-41af-b8ae-be4112c138d7" />

--- a/pages/changelogs/2024-07-17-minute-time-picker.mdx
+++ b/pages/changelogs/2024-07-17-minute-time-picker.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-07-17T18:59:02.165Z"
 updatedAt: "2024-07-17T18:59:02.165Z"
 date: "2024-07-17"
 thumbnail: "/changelog/minute-granularity.png"
-video: "https://www.loom.com/embed/bce6337c491446e9ae6645333f2155e1"
+video: "https://www.loom.com/embed/bce6337c491446e9ae6645333f2155e1?sid=a565791e-d7a5-42b6-a188-525bc68b8a47"
 description: "You choose date ranges that are specified up to the minute. If there's a metric that you want to drill in on for only a few hours, you can set your time range and see only that exact range. This saves you work from having to create a detailed time filter or custom property to do the same thing."
 ---
 
@@ -24,4 +24,4 @@ You choose date ranges that are specified up to the minute. If there's a metric 
 
 This is supported for all chart types in Insights, Funnels, Flows and Retention.
 
-<VideoButtonWithModal src="https://www.loom.com/embed/bce6337c491446e9ae6645333f2155e1" />
+<VideoButtonWithModal src="https://www.loom.com/embed/bce6337c491446e9ae6645333f2155e1?sid=a565791e-d7a5-42b6-a188-525bc68b8a47" />

--- a/pages/changelogs/2024-10-09-metric-units.mdx
+++ b/pages/changelogs/2024-10-09-metric-units.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-10-09T18:59:02.165Z"
 updatedAt: "2024-10-09T18:59:02.165Z"
 date: "2024-10-09"
 thumbnail: "/changelog/metric-units.png"
-video: "https://www.loom.com/embed/da48de90f0fb4e72872b401cad8ed18f"
+video: "https://www.loom.com/embed/da48de90f0fb4e72872b401cad8ed18f?sid=697ba4c5-8f8c-4c5d-a074-7143d6695744"
 description: "Mixpanel now allows you to set the units for each of your metrics. You can set the unit, the precision, and whether or not you want an abbreviated value. This gets updated for tooltips as well as in the table below the chart."
 ---
 
@@ -27,4 +27,4 @@ You can also save the unit to a formula so that future uses of that formula will
 
 Note: this feature is available only for enterprise plans currently.
 
-<VideoButtonWithModal src="https://www.loom.com/embed/da48de90f0fb4e72872b401cad8ed18f" />
+<VideoButtonWithModal src="https://www.loom.com/embed/da48de90f0fb4e72872b401cad8ed18f?sid=697ba4c5-8f8c-4c5d-a074-7143d6695744" />

--- a/pages/changelogs/2024-10-09-segment-coloring.mdx
+++ b/pages/changelogs/2024-10-09-segment-coloring.mdx
@@ -6,7 +6,7 @@ createdAt: "2024-10-09T19:59:02.165Z"
 updatedAt: "2024-10-09T19:59:02.165Z"
 date: "2024-10-09"
 thumbnail: "/changelog/segment-coloring.png"
-video: "https://www.loom.com/embed/164cee809f034b6cb8db3e67adfd3d71"
+video: "https://www.loom.com/embed/164cee809f034b6cb8db3e67adfd3d71?sid=a7f1336e-f6e0-4ddd-9bd9-ced25e9f82df"
 description: "Mixpanel now allows you to select the colors of various segments in your reports. You can choose the color for a particular segment by clicking the legend at the top of the chart. Choose between colors that exist in the theme, or choose an entirely separate color."
 ---
 
@@ -27,4 +27,4 @@ Color selection is available on both boards and reports, so you can easily updat
 
 Note: this feature is available only for enterprise plans currently.
 
-<VideoButtonWithModal src="https://www.loom.com/embed/164cee809f034b6cb8db3e67adfd3d71" />
+<VideoButtonWithModal src="https://www.loom.com/embed/164cee809f034b6cb8db3e67adfd3d71?sid=a7f1336e-f6e0-4ddd-9bd9-ced25e9f82df" />


### PR DESCRIPTION
Before: 

<img width="1324" alt="Screenshot 2024-11-22 at 4 04 10 PM" src="https://github.com/user-attachments/assets/677926f8-fcda-436c-8c9d-5561b93de409">

After: 

<img width="1324" alt="Screenshot 2024-11-22 at 4 04 19 PM" src="https://github.com/user-attachments/assets/bf752909-d796-4f8b-921d-3cb408a30e89">
