### PR TITLE
Update identifying-users-simplified.mdx

### DIFF
--- a/pages/docs/tracking-methods/id-management/identifying-users-simplified.mdx
+++ b/pages/docs/tracking-methods/id-management/identifying-users-simplified.mdx
@@ -186,14 +186,6 @@ def track_to_mp(request, event_name, properties):
 
   # Note: leave the first argument blank here, since we're passing $device_id and $user_id as properties.
   mp.track("", event_name, properties)
-
-def identify_user(request):
-  properties = {
-    "$device_id": uuid.uuid4(),
-    "$identified_id": request.user.username
-
-  }
-  track_to_mp(request, "$identify", properties)
 ```
 ## Best Practices
 


### PR DESCRIPTION
Updating the Python pseudocode for Simplified ID Merge.

Having the function:
def identify_user(request):
  properties = {
    "$device_id": uuid.uuid4(),
    "$identified_id": request.user.username
 
  }
  track_to_mp(request, "$identify", properties)

may cause confusion because $identify is not used id v3 nor is $identified_id. The main part of the pseudocode should suffice as an example as only $device_id and $user_id are used for v3