### PR TITLE
Document `record_canvas` option in JS SDK section

### DIFF
--- a/pages/docs/tracking-methods/sdks/javascript.mdx
+++ b/pages/docs/tracking-methods/sdks/javascript.mdx
@@ -781,6 +781,7 @@ If you already have the JS SDK installed, this is the only code change you need 
 | `record_max_ms` | Maximum length of a single replay in milliseconds. Up to 24 hours is supported. Once a replay has reached the maximum length, a new one will begin. | `86400000`<br/>(24 hours) |
 | `record_min_ms` | Minimum length of a single replay in milliseconds. Up to 8 seconds is supported. If a replay does not meet the minimum length, it will be discarded. | `0`<br/>(0 seconds) |
 | `record_sessions_percent` | Percentage of SDK initializations that will qualify for replay data capture. A value of "1" = 1%. | `0` |
+| `record_canvas` | When true, Mixpanel will record snapshots of `<canvas>` elements on your site at up to 15 frames per second | `false` |
 
 
 ### Session Replay Methods


### PR DESCRIPTION
Released in JS SDK v2.58.0.
- changelog: https://github.com/mixpanel/mixpanel-js/blob/v2.58.0/CHANGELOG.md
- the feature changeset: https://github.com/mixpanel/mixpanel-js-private/pull/240