### PR TITLE
Make search bar transparent to fix light mode appearance

### DIFF
--- a/components/Search/Search.module.scss
+++ b/components/Search/Search.module.scss
@@ -3,6 +3,10 @@
   margin-right: 6px;
 }
 
+.searchBar {
+  background: rgba(0, 0, 0, 0);
+}
+
 .searchBar:focus {
   box-shadow: none;
 }


### PR DESCRIPTION
ref https://mixpanel.slack.com/archives/C050U6CQRLZ/p1734558866873079

Before: 
![image](https://github.com/user-attachments/assets/1ce47ad0-b098-4306-9863-7ce95f9e2db2)
![image](https://github.com/user-attachments/assets/5aa24bae-9091-4b1f-8090-4f5bee0b5eef)

After:
![image](https://github.com/user-attachments/assets/7991b9da-18b1-4015-b069-afe349fb2297)
![image](https://github.com/user-attachments/assets/4556e4c3-bd61-464d-8a21-d378a5208380)

* [`components/Search/Search.module.scss`](diffhunk://#diff-38c2e7c005243739bbef087ef3ef81de6445b15ebc3babfdf49980fac4ae531aR6-R9): Added a transparent background to the `.searchBar` class.
