### PR TITLE
Clarify UTM Persistence

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -76,23 +76,23 @@ function trackPageview() {
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
-  // useEffect(() => {
-  //   insertGTMScriptTags();
-  //   trackPageview();
-  //   Object.values(KapaEventNames).forEach((eventName) => {
-  //     // @ts-ignore
-  //     Kapa(eventName, function (args) {
-  //       // prefix kapa's property names to distinguish them from mixpanel's
-  //       const properties = {};
-  //       if (args) {
-  //         Object.keys(args).forEach((keyName) => {
-  //           properties[`${DocsAIPrefix} ${keyName}`] = args[keyName];
-  //         });
-  //       }
-  //       track(`${DocsAIPrefix} ${eventName}`, properties);
-  //     });
-  //   });
-  // }, []);
+  useEffect(() => {
+    insertGTMScriptTags();
+    trackPageview();
+    Object.values(KapaEventNames).forEach((eventName) => {
+      // @ts-ignore
+      Kapa(eventName, function (args) {
+        // prefix kapa's property names to distinguish them from mixpanel's
+        const properties = {};
+        if (args) {
+          Object.keys(args).forEach((keyName) => {
+            properties[`${DocsAIPrefix} ${keyName}`] = args[keyName];
+          });
+        }
+        track(`${DocsAIPrefix} ${eventName}`, properties);
+      });
+    });
+  }, []);
 
   useEffect(() => {
     router.events.on(`routeChangeComplete`, trackPageview);

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -76,23 +76,23 @@ function trackPageview() {
 export default function MyApp({ Component, pageProps }: AppProps) {
   const router = useRouter();
 
-  useEffect(() => {
-    insertGTMScriptTags();
-    trackPageview();
-    Object.values(KapaEventNames).forEach((eventName) => {
-      // @ts-ignore
-      Kapa(eventName, function (args) {
-        // prefix kapa's property names to distinguish them from mixpanel's
-        const properties = {};
-        if (args) {
-          Object.keys(args).forEach((keyName) => {
-            properties[`${DocsAIPrefix} ${keyName}`] = args[keyName];
-          });
-        }
-        track(`${DocsAIPrefix} ${eventName}`, properties);
-      });
-    });
-  }, []);
+  // useEffect(() => {
+  //   insertGTMScriptTags();
+  //   trackPageview();
+  //   Object.values(KapaEventNames).forEach((eventName) => {
+  //     // @ts-ignore
+  //     Kapa(eventName, function (args) {
+  //       // prefix kapa's property names to distinguish them from mixpanel's
+  //       const properties = {};
+  //       if (args) {
+  //         Object.keys(args).forEach((keyName) => {
+  //           properties[`${DocsAIPrefix} ${keyName}`] = args[keyName];
+  //         });
+  //       }
+  //       track(`${DocsAIPrefix} ${eventName}`, properties);
+  //     });
+  //   });
+  // }, []);
 
   useEffect(() => {
     router.events.on(`routeChangeComplete`, trackPageview);

--- a/pages/docs/tracking-best-practices/traffic-attribution.mdx
+++ b/pages/docs/tracking-best-practices/traffic-attribution.mdx
@@ -6,7 +6,7 @@ When setting up your Mixpanel implementation, one issue of particular interest i
 
 ### UTM Properties
 
-Mixpanel's Javascript library tracks all [UTM tags](/docs/tracking-methods/sdks/javascript#tracking-utm-parameters) by default. This allows you to segment key actions by relevant campaign information using [attribution models](/docs/features/attribution), so that you can quantify the effectiveness of specific campaigns.
+Mixpanel's Javascript library tracks all [UTM tags](/docs/tracking-methods/sdks/javascript#track-utm-tags) by default. This allows you to segment key actions by relevant campaign information using [attribution models](/docs/features/attribution), so that you can quantify the effectiveness of specific campaigns.
 
 Mixpanel's Javascript library will also track initial_utm_parameters as a profile property, based on the first ever visit. This is helpful as if a user makes a purchase or completes some other important event, it is important to know want to know what acquisition channel brought them to your site originally.
 
@@ -21,75 +21,7 @@ Mixpanel's Javascript library will also track initial_utm_parameters as a profil
 - utm_marketing_tactic: targeting criteria applied to a campaign, for example: remarketing, prospecting
 - Initial UTM: tracks the first time a user reaches any of the above parameters
 
-#### Last-Touch UTM tracking
-
-By default, Mixpanel's Javascript SDK tracks UTM tags in a first-touch manner by setting the first UTM tags detected for the user as a profile property and super property. This allows you to see what acquisition channel brought your users to your website originally.
-
-It can also be helpful to track UTM tags in a last-touch manner, which would set the UTM tag to the most recent value detected for the user. This allows you to evaluate the effectiveness of more recent acquisition channels on your user's behavior.
-
-The Javascript SDK does not track last-touch UTM tags by default, but you can add the following code in your website to automatically parse the UTM tags from the current URL, and register the tags as last-touch UTM super properties and profile properties.
-
-
-```javascript
-// Paste the following code below the Mixpanel Javascript Snippet 
-// that you add to your site to track events.
-
-function getQueryParam(url, param) {
-  // Expects a raw URL
-  param = param.replace(/[[]/, "\[").replace(/[]]/, "\]");
-
-  var regexS = "[\?&]" + param + "=([^&#]*)",
-      regex = new RegExp( regexS ),
-      results = regex.exec(url);
-
-  if (results === null || (results && typeof(results[1]) !== 'string' && results[1].length)) {
-    return '';
-  } else {
-    return decodeURIComponent(results[1]).replace(/\W/gi, ' ');
-  }
-};
-
-function campaignParams() {
-
-  // campaign_keywords sets the UTM tags to parse for
-  var campaign_keywords = 'utm_source utm_medium utm_campaign utm_content utm_term'.split(' ')
-      , kw = ''
-      , last_params = {}
-      , first_params = {};
-
-  var index;
-
-  //save UTM tags parsed from the URL as a key-value pair
-  //used to set last-touch UTM properties
-  for (index = 0; index < campaign_keywords.length; ++index) {
-    kw = getQueryParam(document.URL, campaign_keywords[index]);
-    if (kw.length) {
-      last_params[campaign_keywords[index] + ' [last touch]'] = kw;
-    }
-  }
-
-  //save UTM tags parsed from the URL as a key-value pair
-  //used to set first-touch UTM properties
-  for (index = 0; index < campaign_keywords.length; ++index) {
-    kw = getQueryParam(document.URL, campaign_keywords[index]);
-    if (kw.length) {
-      first_params[campaign_keywords[index] + ' [first touch]'] = kw;
-    }
-  }
-
-  //set last-touch UTM tags as profile properties
-  mixpanel.people.set(last_params);
-  //update last-touch UTM super property with the latest value
-  mixpanel.register(last_params);
-
-  //set first-touch UTM tag as profile property
-  //will be skipped if the property is already present
-  mixpanel.people.set_once(first_params);
-
-}
-
-campaignParams();
-```
+UTM parameters are by default persisted across events as [Super Properties](/docs/tracking-methods/sdks/javascript#setting-super-properties). To opt in to the recommended modern behavior most compatible with our [attribution models](/docs/features/attribution), use the SDK initialization option `{stop_utm_persistence: true}` to disable UTM param persistence (refer to our [Release Notes](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.52.0) in GitHub).
 
 ### Initial Referrer and Initial Referring Domain Properties
 

--- a/pages/docs/tracking-methods/sdks/javascript.mdx
+++ b/pages/docs/tracking-methods/sdks/javascript.mdx
@@ -284,17 +284,58 @@ mixpanel.track_pageview({
 
 ### Track UTM Tags
 
-The JavaScript library will automatically add any UTM parameters (`utm_source`, `utm_campaign`, `utm_medium`, `utm_term`, `utm_content`, `utm_id`, `utm_source_platform`, `utm_campaign_id`, `utm_creative_format`, `utm_marketing_tactic`) present on the page to events fired from that page load. Please note when configuring UTMs that UTM tracking is case sensitive, and should be formatted lower-case as shown in the examples above.
+The JavaScript library will automatically add the following UTM parameters present on the page to events fired from that page load:
+- utm_source
+- utm_campaign
+- utm_medium
+- utm_term
+- utm_content
+- utm_id
+- utm_source_platform
+- utm_campaign_id
+- utm_creative_format
+- utm_marketing_tactic
 
-When UTM parameters for an identified user are seen for the first time, these will also be stored on the user profile as `initial_utm_source`, `initial_utm_campaign`, `initial_utm_medium`, `initial_utm_term`, `initial_utm_content`, `initial_utm_id`, `initial_utm_source_platform`, `initial_utm_campaign_id`, `initial_utm_creative_format`, and `initial_utm_marketing_tactic`.
+<Callout type="warning">
+    UTM tracking is case sensitive and should be formatted in lowercase as shown in the examples above.
+</Callout>
 
-In addition to UTM parameters, Mixpanel will also add any advertising click IDs to events fired. These include `dclid`, `fbclid`, `gclid`, `ko_click_id`, `li_fat_id`, `msclkid`, `sccid`, `ttclid`, `twclid`, `wbraid`.
+UTM parameters are by default persisted across events as [Super Properties](/docs/tracking-methods/sdks/javascript#setting-super-properties). To opt in to the recommended modern behavior most compatible with our [attribution models](/docs/features/attribution), use the SDK initialization option `{stop_utm_persistence: true}` to disable UTM param persistence (refer to our [Release Notes](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.52.0) in GitHub).
+
+**Example Usage**
+
+```javascript Javascript
+//create an instance of the Mixpanel object
+mixpanel.init('YOUR_PROJECT_TOKEN', {
+    stop_utm_persistence: true    // disable utm persistence
+    });
+```
+
+When UTM parameters for an identified user are seen for the first time, these will also be stored on the user profile as the following user properties:
+- initial_utm_source
+- initial_utm_campaign
+- initial_utm_medium
+- initial_utm_term
+- initial_utm_content
+- initial_utm_id
+- initial_utm_source_platform
+- initial_utm_campaign_id
+- initial_utm_creative_format
+- initial_utm_marketing_tactic
+
+In addition to UTM parameters, Mixpanel will also add any advertising click IDs to events fired. These include:
+- dclid
+- fbclid
+- gclid
+- ko_click_id
+- li_fat_id
+- msclkid
+- sccid
+- ttclid
+- twclid
+- wbraid
 
 Learn more about [UTM tracking](/docs/tracking-best-practices/traffic-attribution#web-attribution).
-
-<Callout type="info">
-    Note: UTM parameters are by default persisted as [Super Properties](/docs/tracking-methods/sdks/javascript#setting-super-properties). To disable this UTM persistence, use the SDK initialization option `{stop_utm_persistence: true}` (refer to our [Release Notes](https://github.com/mixpanel/mixpanel-js/releases/tag/v2.52.0) in GitHub).
-</Callout>
 
 #### Other Tracking Methods
 There are other less common methods for sending data to Mixpanel. Refer to the [full API documentation](https://github.com/mixpanel/mixpanel-js/blob/master/doc/readme.io/javascript-full-api-reference.md#mixpanel).


### PR DESCRIPTION
- removed reference to last touch UTM tag custom setup since this is the default behavior for JS SDK
- make UTM section of JS SDK more pleasing to the eyes
- emphasize recommendation to disable UTM persistence, most compatible with attribution models