### PR TITLE
Fix typo: 'tp' → 'to' in React Native docs

### DIFF
--- a/pages/docs/tracking-methods/sdks/react-native.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native.mdx
@@ -16,7 +16,7 @@ After [setting up your development environment for React Native](https://reactna
 npm install mixpanel-react-native
 ```
 
-Then navigate tp your application's iOS folder, and install the dependencies. (Note you do not need to update your Podfile to add Mixpanel.)
+Then navigate to your application's iOS folder, and install the dependencies. (Note you do not need to update your Podfile to add Mixpanel.)
 
 ```bash
 pod install


### PR DESCRIPTION
I was reading the guide today as I needed to integrate it into one of our applications and found this typo. This might be my first open-source contribution! 😊