### PR TITLE
[Kapa Bug] Remove Event Listener snippet

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -79,19 +79,22 @@ export default function MyApp({ Component, pageProps }: AppProps) {
   useEffect(() => {
     insertGTMScriptTags();
     trackPageview();
-    Object.values(KapaEventNames).forEach((eventName) => {
-      // @ts-ignore
-      Kapa(eventName, function (args) {
-        // prefix kapa's property names to distinguish them from mixpanel's
-        const properties = {};
-        if (args) {
-          Object.keys(args).forEach((keyName) => {
-            properties[`${DocsAIPrefix} ${keyName}`] = args[keyName];
-          });
-        }
-        track(`${DocsAIPrefix} ${eventName}`, properties);
-      });
-    });
+    // TODO: Based on their doc: https://docs.kapa.ai/integrations/website-widget/javascript-api/events
+    // we should be able to use `Kapa` as a function like below, but it seems like the global object interface has changed
+    // which is throwing Kapa is not a function error. I will follow up w/ Kapa team to see what's up.
+    // Object.values(KapaEventNames).forEach((eventName) => {
+    //   // @ts-ignore
+    //   Kapa(eventName, function (args) {
+    //     // prefix kapa's property names to distinguish them from mixpanel's
+    //     const properties = {};
+    //     if (args) {
+    //       Object.keys(args).forEach((keyName) => {
+    //         properties[`${DocsAIPrefix} ${keyName}`] = args[keyName];
+    //       });
+    //     }
+    //     track(`${DocsAIPrefix} ${eventName}`, properties);
+    //   });
+    // });
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
[Based on their doc,](https://docs.kapa.ai/integrations/website-widget/javascript-api/events) we should be able to do the following
```
// Adding an event listener
Kapa("onAskAIQuerySubmit", function (args) {
  /* do something */
});
```
which let us add custom event handler. But, it seems like the Global `Kapa` object has been changed

![Screenshot 2025-02-07 at 9 45 47 AM](https://github.com/user-attachments/assets/a3ee946c-0a17-40c7-a237-1cb60d08eaeb)

Removing the code for now until I follow up w/ the Kapa team.
