### PR TITLE
Fix scroll position issue, make copyright date dynamic, match image styles across doc layouts

### DIFF
--- a/pages/docs/_meta.tsx
+++ b/pages/docs/_meta.tsx
@@ -1,69 +1,93 @@
 import {
-	AdminIcon,
-	AnalysisIcon,
-	DataInIcon,
-	DataOutIcon,
-	IntroIcon,
-	SupportIcon,
-  } from "../../components/svg/NavIcon";
+  AdminIcon,
+  AnalysisIcon,
+  DataInIcon,
+  DataOutIcon,
+  IntroIcon,
+  SupportIcon,
+} from "../../components/svg/NavIcon";
 
 import style from "./sidebar.module.scss";
 
-  export default {
-	"intro": {
-		"type": "separator",
-		"title": <div className={style.titleContainer}><IntroIcon /> INTRO</div>,
-	},
-	"what-is-mixpanel": "What is Mixpanel?",
-	"what-to-track": "What to Track",
-	"quickstart": "Quickstart",
-	"data-in": {
-		"type": "separator",
-		"title": <div className={style.titleContainer}><DataInIcon /> DATA IN</div>,
-	},
-	"tracking-methods": "Tracking Methods",
-	"data-structure": "Data Structure",
-	"migration": "Migration",
-	"tracking-best-practices": "Best Practices",
-	"analysis": {
-		"type": "separator",
-		"title": <div className={style.titleContainer}><AnalysisIcon /> ANALYSIS</div>,
-	},
-	"reports": "Reports",
-	"boards": "Boards",
-	"users": "Users",
-	"session-replay": "Session Replay",
-	"features": "Features",
-	"admin": {
-		"type": "separator",
-		"title": <div className={style.titleContainer}><AdminIcon /> ADMIN</div>,
-	},
-	"orgs-and-projects": "Orgs & Projects",
-	"data-governance": "Data Governance",
-	"access-security": "Access Security",
-	"privacy": "Privacy",
-	"pricing": "Pricing",
-	"data-out": {
-		"type": "separator",
-		"title": <div className={style.titleContainer}><DataOutIcon /> DATA OUT</div>,
-	},
-	"export-methods": "Export Methods",
-	"data-pipelines": "Data Pipelines",
-	"cohort-sync": "Cohort Sync",
-	"support": {
-		"type": "separator",
-		"title": <div className={style.titleContainer}><SupportIcon /> SUPPORT</div>,
-	},
-	"community": "Community",
-	"get-help": {
-		"title": "Get Help ↗",
-		"newWindow": true,
-		"href": "https://mixpanel.com/get-support"
-	},
-	"response-times": "Response Times",
-	"hire-an-expert": {
-		"title": "Hire an Expert ↗",
-		"newWindow": true,
-		"href": "https://mixpanel.com/partners/experts/matchmaking"
-	}
-}
+export default {
+  intro: {
+    type: "separator",
+    title: (
+      <div className={style.titleContainer}>
+        <IntroIcon /> INTRO
+      </div>
+    ),
+  },
+  "what-is-mixpanel": "What is Mixpanel?",
+  "what-to-track": "What to Track",
+  quickstart: "Quickstart",
+  "data-in": {
+    type: "separator",
+    title: (
+      <div className={style.titleContainer}>
+        <DataInIcon /> DATA IN
+      </div>
+    ),
+  },
+  "tracking-methods": "Tracking Methods",
+  "data-structure": "Data Structure",
+  migration: "Migration",
+  "tracking-best-practices": "Best Practices",
+  analysis: {
+    type: "separator",
+    title: (
+      <div className={style.titleContainer}>
+        <AnalysisIcon /> ANALYSIS
+      </div>
+    ),
+  },
+  reports: "Reports",
+  boards: "Boards",
+  users: "Users",
+  "session-replay": "Session Replay",
+  features: "Features",
+  admin: {
+    type: "separator",
+    title: (
+      <div className={style.titleContainer}>
+        <AdminIcon /> ADMIN
+      </div>
+    ),
+  },
+  "orgs-and-projects": "Orgs & Projects",
+  "data-governance": "Data Governance",
+  "access-security": "Access Security",
+  privacy: "Privacy",
+  pricing: "Pricing",
+  "data-out": {
+    type: "separator",
+    title: (
+      <div className={style.titleContainer}>
+        <DataOutIcon /> DATA OUT
+      </div>
+    ),
+  },
+  "export-methods": "Export Methods",
+  "data-pipelines": "Data Pipelines",
+  "cohort-sync": "Cohort Sync",
+  support: {
+    type: "separator",
+    title: (
+      <div className={style.titleContainer}>
+        <SupportIcon /> SUPPORT
+      </div>
+    ),
+  },
+  community: "Community",
+  "get-help": {
+    title: "Get Help ↗",
+    newWindow: true,
+    href: "https://mixpanel.com/get-support",
+  },
+  "response-times": "Response Times",
+  "hire-an-expert": {
+    title: "Hire an Expert ↗",
+    newWindow: true,
+    href: "https://mixpanel.com/partners/experts/matchmaking",
+  },
+};

--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -467,9 +467,28 @@ $border-radius-lg: 100px;
   opacity: 1 !important;
 }
 
-// Add BG color to image with transparent background
-article img {
-  background-color: colors.$lightbg;
+// Add image frame styling to prevent layout-reflow and match custom layout image styling (changelog) with nextra layout
+article p:has(img) {
+  background-color: color.adjust(colors.$grey20, $alpha: -0.95);
+  border-radius: 1.5rem;
+  aspect-ratio: 16/9;
+  padding-left: 2rem;
+  padding-right: 2rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow: hidden;
+  width: 100%;
+
+  img {
+    border-radius: 1rem;
+    width: 100%;
+  }
+
+  @media (min-width: 1024px) {
+    padding-left: 3.5rem;
+    padding-right: 3.5rem;
+  }
 }
 
 //##############################Light Theme Starts Here##################################

--- a/pages/theme/colors.scss
+++ b/pages/theme/colors.scss
@@ -40,6 +40,7 @@ $grey100: #201f24;
 $grey80: #626266;
 $grey50: #9b9b9b;
 $grey30: #c0c0c0;
+$grey20: #eae7e7;
 $grey10: #e9e9e9;
 $white: #fff;
 

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -8,12 +8,6 @@ import SignUpButton from "./components/SignUpButton/SignUpButton";
 import ChangelogPostHeader from "./components/ChangelogPostHeader/ChangelogPostHeader";
 import { VideoButtonWithModal } from "./components/VideoButtonWithModal";
 
-function renderComponent<T>(ComponentOrNode: FC<T> | ReactNode, props?: T) {
-  if (!ComponentOrNode) return null;
-  if (typeof ComponentOrNode !== "function") return ComponentOrNode;
-  return <ComponentOrNode {...props} />;
-}
-
 const config: DocsThemeConfig = {
   darkMode: true,
   nextThemes: {

--- a/theme.config.tsx
+++ b/theme.config.tsx
@@ -66,7 +66,7 @@ const config: DocsThemeConfig = {
     useLink: () => "https://mixpanel.com/get-support",
   },
   footer: {
-    content: "© Mixpanel 2024",
+    content: `© Mixpanel ${new Date().getFullYear()}`,
   },
   logo: <MixpanelLogoWordmark width={125} />,
   logoLink: "https://mixpanel.com/home/",


### PR DESCRIPTION
Fix reflow issue with anchor location ([thread](https://mixpanel.slack.com/archives/C04TJL0J0/p1743433204454239))

Loom of fix: https://www.loom.com/share/c3bb35a259d344608a711aa3462a1477

- Smooth scroll ended on incorrect location b/c of image loading layout reflow issue
- This also matches nextra's image styling with custom layout so all images are styled consistently (as on [changelog](https://docs.mixpanel.com/changelogs))

|Before|After|
|--|--|
|<img width="1477" alt="before-docs-2" src="https://github.com/user-attachments/assets/dd775682-89a9-41ab-a9b9-8b822139259f" />|<img width="1477" alt="after-docs-2" src="https://github.com/user-attachments/assets/71866c8b-8edf-4144-aa05-bc8e6a437e92" />|
|<img width="1477" alt="before-docs-1" src="https://github.com/user-attachments/assets/2cc5b6ea-c252-478b-8dda-13595b2230ae" />|<img width="1477" alt="after-docs-1" src="https://github.com/user-attachments/assets/85cc2b3e-25d0-46a2-9ede-5ddc08bb8677" />|
|<img width="1477" alt="before-guide-1" src="https://github.com/user-attachments/assets/734d8553-bb12-4406-8219-a52c6574d322" />|<img width="1477" alt="after-guide-1" src="https://github.com/user-attachments/assets/a17806f0-22e5-43e9-8bed-624cd8b8b68c" />|
