### PR TITLE
[Docs] remove max width on docs

### DIFF
--- a/pages/overrides.scss
+++ b/pages/overrides.scss
@@ -467,6 +467,10 @@ $border-radius-lg: 100px;
   opacity: 1 !important;
 }
 
+._max-w-\[90rem\] {
+  max-width: 100% !important;
+}
+
 // Add image frame styling to prevent layout-reflow and match custom layout image styling (changelog) with nextra layout
 
 article {
@@ -509,9 +513,7 @@ article {
         margin-top: 1rem;
       }
     }
-
   }
-
 }
 
 //##############################Light Theme Starts Here##################################


### PR DESCRIPTION
slack thread: https://mixpanel.slack.com/archives/C050U6CQRLZ/p1745830340536249

screenshot of changes:
<img width="2321" alt="Screenshot 2025-05-06 at 3 51 32 PM" src="https://github.com/user-attachments/assets/30d74b43-396f-486d-a96f-5e1b6ad4f933" />
