### PR TITLE
Remove mentions to contact support to request higher object lmt 

### DIFF
--- a/pages/docs/data-structure/property-reference/data-type.mdx
+++ b/pages/docs/data-structure/property-reference/data-type.mdx
@@ -58,7 +58,7 @@ Mixpanel supports five data types for properties: String, Numeric, Boolean, Date
 
 - A JSON array of 1 level JSON objects with each object having similar sets of key-value pairs e.g. Cart = `[{"Brand":"Puma","Category":"Jacket","Price":30}, {"Brand":"Adidas","Category":"Hats","Price":15}]`
 - Limits of a List of Objects: Event Property = 8KB, User Profile Property = 256KB, max 255 keys and no nesting
-- Projects with fewer than 100 million events per month can include up to 20 objects per list. For projects exceeding this threshold, the system supports only the first 5 objects in each list. (Customers on a paid plan may request a limit increase by [submitting a support ticket](https://mixpanel.com/get-support).)
+- Projects with fewer than 100 million events per month can include up to 20 objects per list. For projects exceeding this threshold, the system supports only the first 5 objects in each list.
 - Mainly supported in core reports (i.e. Insights, Funnels, Flows, Retention, Users / Cohorts, Events) as filters and breakdowns. Property Names (ie keys) within an object are not supported in Lexicon.
 
 ## List Property Support

--- a/pages/docs/data-structure/property-reference/data-type.mdx
+++ b/pages/docs/data-structure/property-reference/data-type.mdx
@@ -277,7 +277,7 @@ In each case, the object will have multiple properties, such as "price" and "bra
 }
 ```
 
-Projects with fewer than 100 million events per month can include up to 20 objects per list. For projects exceeding this threshold, the system supports only the first 5 objects in each list. Customers on a paid plan may request a limit increase by [submitting a support ticket](https://mixpanel.com/get-support).
+Projects with fewer than 100 million events per month can include up to 20 objects per list. For projects exceeding this threshold, the system supports only the first 5 objects in each list.
 
 ### Breakdown and Filter
 List of objects can be used like other properties in Mixpanel. Upon selecting a list of objects property, you will be prompted to select another property common to the objects in the list. Usage in measurements, filters, and breakdowns follows the same behavior as other [list properties](/docs/data-structure/property-reference/data-type#list-property-support).


### PR DESCRIPTION
Removing that customers with a paid plan can write in the request > 20 object limits. We are only currently only entertaining this for customers who have a plan with $100k+ ARR. "Paid plan" is too broad. Also most customers with $100k+ ARR should have an account team to facilitate this request internally.