### PR TITLE
Shared SSO is available by request

### DIFF
--- a/pages/docs/access-security/single-sign-on/shared-sso.mdx
+++ b/pages/docs/access-security/single-sign-on/shared-sso.mdx
@@ -11,7 +11,7 @@ With a shared SSO setup, Single Sign-On settings and Claimed Domains are adminis
 This feature is available to customers on an Enterprise Plan.
 
 <Callout type="info">
-    Shared SSO is currently in private beta. Please contact your Account Manager if you are interested in enabling this feature.
+    Shared SSO is available by request. Please contact your Account Manager if you are interested in enabling this feature.
 </Callout>
 
 ## Admin Organizations


### PR DESCRIPTION
Shared SSO is available by request; it is no longer considered beta. But because of the implementation complexity, we want customers to ask for it. Updated callout in Shared SSO doc to reflect this.