### PR TITLE
Fix Android setTrackAutomaticEvents

### DIFF
--- a/pages/docs/tracking-methods/sdks/android.mdx
+++ b/pages/docs/tracking-methods/sdks/android.mdx
@@ -91,9 +91,6 @@ The [`MPConfig`](https://mixpanel.github.io/mixpanel-android/com/mixpanel/androi
 trackAutomaticEvents = true;
 MixpanelAPI mixpanel = 
     MixpanelAPI.getInstance(this, "YOUR_PROJECT_TOKEN", trackAutomaticEvents);
-
-// enable automatic events after initialization
-mixpanel.setTrackAutomaticEvents(false);
 ```
 
 ## Sending Events


### PR DESCRIPTION
Automatic Events cannot be enabled after initialization. 

This setting is only available when initializing the Mixpanel instance.

mixpanel.setTrackAutomaticEvents() does not exist