### PR TITLE
Added missing autocapture props

### DIFF
--- a/pages/docs/tracking-methods/sdks/javascript.mdx
+++ b/pages/docs/tracking-methods/sdks/javascript.mdx
@@ -212,8 +212,14 @@ On Autocapture events, Mixpanel default-tracks the following properties:
 | `$clientY` | The Y-coordinate of the mouse pointer relative to the browser’s viewport when the event occurred. |
 | `$offsetX` | The X-coordinate of the mouse pointer relative to the event target element. |
 | `$offsetY` | The Y-coordinate of the mouse pointer relative to the event target element. |
+| `$pageHeight` | The height of the full page. |
+| `$pageWidth` | The width of the full page. |
 | `$pageX` | The X-coordinate of the mouse pointer relative to the full page. |
 | `$pageY` | The Y-coordinate of the mouse pointer relative to the full page. |
+| `$scroll_checkpoint` | The percentage of scrollbar that has been reached when crossing specific thresholds (e.g., 25%, 50%, 75%, 100%). |
+| `$scroll_height` | The height of the scrollable area of the page. |
+| `$scroll_percentage` | The percentage of the page that has been scrolled. |
+| `$scroll_top` | The number of pixels the page has been scrolled vertically. |
 | `$screenX` | The X-coordinate of the mouse pointer relative to the screen. |
 | `$screenY` | The Y-coordinate of the mouse pointer relative to the screen. |
 | `$x` | The X-coordinate of the event, often synonymous with `$pageX`. |


### PR DESCRIPTION
Added `$pageHeight`, `$pageWidth`, `$scroll_checkpoint`, `$scroll_height`, `$scroll_percentage`, `$scroll_top` as autocapture properties