### PR TITLE
More SR GA Updates

### DIFF
--- a/pages/docs/session-replay/implement-session-replay/session-replay-ios.mdx
+++ b/pages/docs/session-replay/implement-session-replay/session-replay-ios.mdx
@@ -87,7 +87,7 @@ You can capture replay data using a sampling method (recommended), or customize 
 
 We recommend using our sampling functionality unless you need custom logic to decide when to record sessions.
 
-To enable Session Replay and set your sampling rate, create a `MPSessionReplayConfig` object and set the `autoStartRecordingSessionsPercent` with a value between `0.0` and `100.0`. At `0.0` no sessions will be recorded, at `100.0` (default) all sessions will be recorded.
+To enable Session Replay and set your sampling rate, create a `MPSessionReplayConfig` object and set the `recordingSessionsPercent` with a value between `0.0` and `100.0`. At `0.0` no sessions will be recorded, at `100.0` (default) all sessions will be recorded.
 
 Start with a low sampling rate, then adjust according to your specific analytics needs.
 
@@ -97,7 +97,7 @@ Upon initialization, recording starts automatically if the sampling check passes
 
 ```swift Swift
 // records 1% of all sessions
-MPSessionReplayConfig(autoStartRecordingSessionsPercent: 1.0)
+MPSessionReplayConfig(recordingSessionsPercent: 1.0)
 ```
 
 ### Manual Recording
@@ -106,7 +106,7 @@ To programatically start and stop replay capture, use the `.startRecording()` an
 
 #### Start Recording Replay Data
 
-Calling `.startRecording()` will force recording to begin regardless of the `autoStartRecordingSessionsPercent` sampling check.
+Calling `.startRecording()` will force recording to begin regardless of the `recordingSessionsPercent` sampling check.
 
 Recording automatically stops when the app goes into the background. If `autoStartRecording` is `true` (default) recording automatically re-starts when the app comes back to the foreground.
 
@@ -120,7 +120,7 @@ MPSessionReplay.getInstance()?.startRecording()
 
 ```swift Swift
 // manually force recording to begin with a 50% sampling rate
-MPSessionReplay.getInstance()?.startRecording(recordSessionsPercent: 50.0)
+MPSessionReplay.getInstance()?.startRecording(sessionsPercent: 50.0)
 ```
 
 #### Stop Recording Replay Data
@@ -169,7 +169,7 @@ Currently, there are six config options:
 | `wifiOnly` | When `true`, replay events will only be flushed to the server when the device has a WiFi connection. If there is no wifi, flushes are skipped and the events remain in the in-memory queue until wifi is restored (or until the queue reaches its limit and the oldest events are evicted to make room for newer events). <br/> When `false`, replay events will be flushed with any network connection, including cellular. | `true` |
 | `autoMaskedViews` | This is a `Set` of enum options for the types of views that should be masked by the SDK automatically. | `[.image, .text, .web, .map]` |
 | `autoStartRecording` | This is a boolean value that determines whether or not recording begins automatically upon initialization and when returning to the foreground. | `true` |
-| `autoStartRecordingSessionsPercent` | This is a value between `0.0` and `100.0` (default) that controls the sampling rate for automatically triggered session replays. <br/> At `0.0` no sessions will be recorded. At `100.0` all sessions will be recorded.  | `100.0` |
+| `recordingSessionsPercent` | This is a value between `0.0` and `100.0` (default) that controls the sampling rate for automatically triggered session replays. <br/> At `0.0` no sessions will be recorded. At `100.0` all sessions will be recorded.  | `100.0` |
 | `flushInterval` | Specifies the flush interval (in seconds) at which session replay events are sent to the Mixpanel server. | `10` |
 | `enableLogging` | This is a boolean value that determines whether or not debugging logs are printed to the console. | `false` |
 

--- a/pages/docs/session-replay/implement-session-replay/session-replay-ios.mdx
+++ b/pages/docs/session-replay/implement-session-replay/session-replay-ios.mdx
@@ -341,12 +341,6 @@ bgImage.mpReplaySensitive = false
 
 By default, Mixpanel retains Session Replays for 30 days from the date the replay is ingested and becomes available for viewing within Mixpanel. Customers on our [Enterprise plan](https://mixpanel.com/pricing/) can customize this retention period between 7 days and 360 days. Once a replay is expired, there is no way to view that replay.
 
-### Legal (Beta Terms)
-
-Our Session Replay Beta Service Addendum can be found [here](https://mixpanel.com/legal/session-replay-beta-service-addendum/).
-
-The alpha and beta of Mixpanel's mobile session replay SDK will track certain events and send them to Mixpanel so that Mixpanel can understand and improve the alpha and beta mobile session replay feature experience. These events include starting and stopping a session, adding and removing sensitive classes, adding sensitive views and adding safe views. Nothing about your application will be included in this tracking; only your usage of the Mixpanel Session Replay SDK.
-
 ## FAQ
 
 #### How does Session Replay work in iOS?

--- a/pages/docs/tracking-methods/sdks/android/android-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/android/android-replay.mdx
@@ -290,12 +290,6 @@ Along with other data, the SDK respects all Do Not Track (DNT) settings as well 
 
 By default, Mixpanel retains Session Replays for 30 days from the date the replay is ingested and becomes available for viewing within Mixpanel. Customers on our [Enterprise plan](https://mixpanel.com/pricing/) can customize this retention period between 7 days and 360 days. Once a replay is expired, there is no way to view that replay.
 
-### Legal (Beta Terms)
-
-Our Session Replay Beta Service Addendum can be found [here](https://mixpanel.com/legal/session-replay-beta-service-addendum/).
-
-The alpha and beta of Mixpanel's mobile session replay SDK will track certain events and send them to Mixpanel so that Mixpanel can understand and improve the alpha and beta mobile session replay feature experience. These events include starting and stopping a session, adding and removing sensitive classes, adding sensitive views and adding safe views. Nothing about your application will be included in this tracking; only your usage of the Mixpanel Session Replay SDK.
-
 ## FAQ
 
 #### How does Session Replay work in Android?

--- a/pages/docs/tracking-methods/sdks/android/android-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/android/android-replay.mdx
@@ -91,7 +91,7 @@ When calling `.startRecording()` recording always begins regardless of the `reco
 
 ```kotlin
 // start recording with a specified sampling rate (10%)
-MPSessionReplay.getInstance()?.startRecording(withSessionsPercent: 10.0)
+MPSessionReplay.getInstance()?.startRecording(sessionsPercent: 10.0)
 ```
 
 Recording automatically stops when the app goes into the background. If the `autoStartRecording` configuration is `true` (default) recording will automatically start when the app returns to the foreground.

--- a/pages/docs/tracking-methods/sdks/android/android-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/android/android-replay.mdx
@@ -2,55 +2,39 @@ import { Callout } from 'nextra/components'
 
 # Mixpanel Session Replay SDKs: Android
 
-<Callout type="info">
-Android Session Replay is currently in invite-only Private Alpha. Please reach out to your Account Manager for any questions about Session Replay or Android Alpha access.
-</Callout>
-
 ## Getting started
 
 The Session Replay SDK for Android is an supplementary SDK that complements the [main Android SDK](/docs/tracking-methods/sdks/android), enabling you to visually replay your users' app interactions through the [Session Replay](/docs/session-replay) feature. Please refer to our [developer guide on implementing Session Replay](/docs/session-replay/implement-session-replay/session-replay-android) for a detailed walkthrough.
 
-If you have not installed the main Swift SDK yet, navigate to the [Quickstart Guide](/docs/quickstart).
+If you have not installed the main Android SDK yet, navigate to the [Quickstart Guide](/docs/quickstart).
 
 The [Library Source Code](https://github.com/mixpanel/mixpanel-android-session-replay-package) is documented in our GitHub repo.
 
 ## Installing the Library
 
-You can integrate the Mixpanel Android Session Replay SDK into your Android project by embedding the Android Archive (AAR) file below.
+You can integrate the Mixpanel Android Session Replay SDK into your Android project using Maven Central.
+
+### Add to your project
 
 1. Open your existing Android Studio project where you want to integrate the Mixpanel Android Session Replay SDK.
-2. Download and unzip [mixpanel-android-session-replay.aar.zip](https://mxpnl.notion.site/Mixpanel-Android-Session-Replay-SDK-Alpha-1bbe0ba92562800dacdbec9cb597d397) to your local drive.
-3. Copy the AAR file to the `app/libs` folder in your Android project.
-4. Configure your project's Gradle settings:
-    - For **Kotlin DSL (settings.gradle.kts)**: Add to the repositories section under `dependencyResolutionManagement`:
 
-    ```kotlin Kotlin
-    flatDir {
-        dirs("libs")
-    }
-    ```
-    - For **Groovy DSL (build.gradle)**: Add to the repositories section under `buildScripts`:
-
-    ```groovy
-    flatDir {
-        dirs("libs")
-    }
-    ```
-5. Add the following dependencies to your module's `build.gradle` or `build.gradle.kts`:
+2. Add the following dependency to your module's `build.gradle` or `build.gradle.kts`:
 
 ```gradle
-implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:+")
-implementation("com.squareup.curtains:curtains:+")
-implementation(files("libs/mixpanel-android-session-replay.aar"))
+dependencies {
+    implementation("com.mixpanel.android:mixpanel-android-session-replay:VERSION_NAME")
+}
 ```
 
-6. Sync your project with Gradle files.
+Replace `VERSION_NAME` with the latest version available on [Maven Central](https://central.sonatype.com/artifact/com.mixpanel.android/mixpanel-android-session-replay).
+
+3. Sync your project with Gradle files.
 
 ### Initialize
 
 You should have the main Mixpanel Android SDK installed (minimum version `v8.0.2`). If not, please refer to the [Quickstart Guide](/docs/quickstart). 
 
-Initialize the [`MPSessionReplay`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/MPSessionReplay.kt) SDK in your `Application` class:
+Initialize the `MPSessionReplay` SDK in your `Application` class:
 
 **Example Usage**
 
@@ -65,7 +49,7 @@ private fun initializeMixpanel() {
  
     val config = MPSessionReplayConfig(
         wifiOnly = false,
-        recordSessionsPercent = 100.0
+        enableLogging = true
     )
  
     MPSessionReplay.initialize(this, token, mixpanel.distinctId, config)
@@ -80,83 +64,99 @@ private fun initializeMixpanel() {
 
 You can capturing replay data using a sampling method (recommended), or customize when and where replays are captured manually using methods provided by the Session Replay Android SDK.
 
+By default recording begins automatically upon initialization. This behavior is configurable via the `autoStartRecording` property of `MPSessionReplayConfig`.
+
 ### Sampling
 
-To enable Session Replay and set your sampling rate, create a [`SessionReplayConfig`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/models/MPSessionReplayConfig.kt#L9) object and set the [`recordSessionsPercent`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/models/MPSessionReplayConfig.kt#L11) with a value between `0.0` and `100.0`. 
+We recommend using the sampling method unless you need to customize when you capture replay data.
 
-At `0.0` no sessions will be recorded, at `100.0` all sessions will be recorded.
+To enable Session Replay and set your sampling rate, create a `MPSessionReplayConfig` object and set the `recordingSessionsPercent` with a value between `0.0` and `100.0` (default). At `0.0` no sessions will be recorded, at `100.0` all sessions will be recorded.
+
+Start with a low sampling rate, then adjust according to your specific analytics needs.
 
 **Example Usage**
 
 ```kotlin
 // records 1% of all sessions
-MPSessionReplayConfig(
-            recordSessionsPercent = 1.0
-        )
+MPSessionReplayConfig(recordingSessionsPercent = 1.0)
 ```
 
 ### Manual Capture
 
 To programatically start and stop replay capture, use the `.startRecording()` and `.stopRecording()` methods.
 
-#### Start Recording
+#### Start Capturing Replay 
 
-Call [`.startRecording()`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/MPSessionReplayInstance.kt#L179) to force recording to begin, regardless of the `recordSessionsPercent` init option. 
+When calling `.startRecording()` recording always begins regardless of the `recordingSessionsPercent` configuration. You may optionally specify a sampling percentage when calling `.startRecording()`
 
-The recording automatically stops when the app goes to the background. Therefore, if you want to continuously record the replays, you will need to restart the replay once the app becomes active again.
+```kotlin
+// start recording with a specified sampling rate (10%)
+MPSessionReplay.getInstance()?.startRecording(withSessionsPercent: 10.0)
+```
 
-This will have no effect if replay data collection is already in progress.
+Recording automatically stops when the app goes into the background. If the `autoStartRecording` configuration is `true` (default) recording will automatically start when the app returns to the foreground.
+
+`.startRecording()` will have no effect if recording is already in progress.
 
 **Example Usage**
 
 ```kotlin Kotlin
 // manually trigger a replay capture
 MPSessionReplay.getInstance()?.startRecording()
-// no effect if recording is already in progress
 ```
 
-#### Stop Recording
+#### Stop Capturing Replay Data
 
-Call [`.stopRecording()`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/MPSessionReplayInstance.kt#L222) to stop any active replay data collection. The SDK automatically stops recording when the app goes to the background.
+Call `.stopRecording()` to stop any active replay data collection. The SDK automatically stops recording when the app goes to the background. 
+
+`.stopRecording()` will have no effect if there is no recording in progress.
 
 **Example Usage**
 
 ```kotlin Kotlin
 // manually end a replay capture
 MPSessionReplay.getInstance()?.stopRecording()
-// no effect if no recording in progress
 ```
 
-### Config Options
+#### Example Use Cases for Manual Capture
 
-Upon initialization you can provide a [`SessionReplayConfig`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/models/MPSessionReplayConfig.kt#L9) object to customize your replay capture.
+| Scenario | Guidance | 
+| --- | --- |
+| We have a sensitive screen we don't want to capture | When user is about to access the sensitive screen, call `.stopRecording()`. To resume recording once they leave this screen, you can resume recording with `.startRecording()`  | 
+| We only want to record certain types of users (e.g. Free plan users only) | Using your application code, determine if current user meets the criteria of users you wish to capture. If they do, then call `.startRecording()` to begin recording |
+| We only want to users utilizing certain features | When user is about to access the feature you wish to capture replays for, call `.startRecording()` to begin recording |
 
-Currently, there are three config options:
+### Additional Configuration Options
+
+Upon initialization you can provide a `MPSessionReplayConfig` object to customize your replay capture.
+
+The current configuration options are:
 
 | Option | Description | Default | 
 | --- | --- | --- |
-| [`wifiOnly`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/models/MPSessionReplayConfig.kt#L10) | When `true`, replay events will only be flushed to the server when the device has a WiFi connection. If there is no wifi, flushes are skipped and the events remain in the in-memory queue until wifi is restored (or until the queue reaches its limit and the oldest events are evicted to make room for newer events). <br/> When `false`, replay events will be flushed with any network connection, including cellular. | `true` |
-| [`recordSessionsPercent`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/models/MPSessionReplayConfig.kt#L11) | This is a value between `0.0` and `100.0` that controls the sampling rate for recording session replays. <br/> At `0.0` no sessions will be recorded. At `100.0` all sessions will be recorded.  | `0.0` |
-| [`autoMaskedViews`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/models/MPSessionReplayConfig.kt#L12) | This is a `Set` of enum options for the types of views that should be masked by the SDK automatically. | `Image`, `Text`, and `Web` |
+| `wifiOnly` | When `true`, replay events will only be flushed to the server when the device has a WiFi connection. If there is no wifi, flushes are skipped and the events remain in the in-memory queue until wifi is restored (or until the queue reaches its limit and the oldest events are evicted to make room for newer events). <br/> When `false`, replay events will be flushed with any network connection, including cellular. | `true` |
+| `autoMaskedViews` | This is a `Set` of enum options for the types of views that should be masked by the SDK automatically. | `Image`, `Text`, and `Web` |
+| `autoStartRecording` | This is a boolean value that determines whether or not recording begins automatically upon initialization and when returning to the foreground.  | `true` |
+| `recordingSessionsPercent` | This is a value between `0.0` and `100.0` that controls the sampling rate for recording session replays. <br/> At `0.0` no sessions will be recorded. At `100.0` all sessions will be recorded.  | `100.0` |
+| `flushInterval` | Specifies the flush interval (in seconds) at which session replay events are sent to the Mixpanel server. | `10` |
+| `enableLogging` | This is a boolean value that determines whether or not debugging logs are printed to the console. | `false` |
 
-Note: automasking is supported for apps built with XML-based layouts. For apps using Jetpack Compose, automasking is not yet fully supported. Manual masking controls offer complete functionality, but developers should test carefully to confirm that masking behaves as expected.
-
-**Example Usage**
+**autoMaskedViews Example Usage**
 
 ```kotlin Kotlin
 // mask images only
-// only send recordings on wifi
-MPSessionReplayConfig(
-            wifiOnly = true,
-            autoMaskedViews = mutableSetOf(AutoMaskedView.ImageView)
-        )
+MPSessionReplayConfig(autoMaskedViews = mutableSetOf(AutoMaskedView.ImageView))
+
+// disable auto masking
+MPSessionReplayConfig(autoMaskedViews = emptySet())
+
 ```
 
 #### Mark Views as Sensitive
 
-Mark any views as sensitive by setting the `mpReplaySensitive` property to `true` or calling the [`addSensitiveView()`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/sensitive_views/SensitiveViewManager.kt#L107) method. Views marked as "sensitive" will be masked.
+All `EditText` and `TextView` components are masked by default. `EditText` cannot be unmasked, while `TextView` can be unmasked.
 
-Set `mpReplaySensitive` to `false` or calling the [`removeSensitiveView()`](https://github.com/mixpanel/mixpanel-android-session-replay/blob/13c5726c9573e329120959025cfd6b06b5b3d888/mixpanel-android-session-replay/src/main/java/com/mixpanel/mixpanel_android_session_replay/MPSessionReplayInstance.kt#L157) to mark any view as safe. Views marked as "safe" will not be masked.
+You can also mark any views as sensitive using `mpReplaySensitive` or `addSensitiveView`. Views marked as "sensitive" will be masked.
 
 **Example Usage**
 
@@ -173,27 +173,183 @@ val creditCardView: ImageView = findViewById(R.id.creditCardView)
 MPSessionReplay.getInstance()?.addSensitiveView(creditCardView)
 ```
 
-All `EditText` and `TextView` components are masked by default. `EditText` cannot be unmasked, while `TextView` can be unmasked.
-
-## Get Replay ID
-
-Use the [`getReplayId()`]() method to return the [Replay ID](/docs/session-replay/implement-session-replay/session-replay-android#replay-id) for the current replay recording. The method will return an empty object if there is no active replay capture in progress.
+Set `mpReplaySensitive` to `false` to mark any view as safe. Views marked as "safe" will not be masked.
 
 **Example Usage**
 
-```swift Swift
+```kotlin Kotlin
+// Compose
+Image(
+    painter = painterResource(id = R.drawable.family_photo),
+    contentDescription = "Family Photo",
+    modifier = Modifier.mpReplaySensitive(false)
+)
+```
+
+#### Identity Management
+
+The Mixpanel distinct ID for the current user can be passed into the initializer and changed at runtime by calling the `.identify(distinctId:)` method:
+
+**Example Usage**
+
+```kotlin
+// initialize the main Mixpanel tracking SDK
+ MixpanelAPI.getInstance(this, token, trackAutomaticEvents)
+
+// initialize the session replay SDK with the project token and distinct ID from above
+ MPSessionReplay.initialize(this, token, mixpanel.distinctId)
+```
+
+To change the distinct ID later:
+
+```kotlin
+// for example when the user logs out
+fun logout() {
+    // reset the main Mixpanel tracking SDK to generate a new distinct ID
+    mixpanel.reset()
+    val newDistinctId = mixpanel.distinctId
+    // change session replay distinct ID
+    MPSessionReplay.getInstance()?.identify(distinctId: newDistinctId)
+}
+```
+
+#### Manual Flushing
+
+You can flush any currently queued session replay events at any time by calling `.flush()`:
+
+```kotlin Kotlin
+MPSessionReplay.getInstance()?.flush()
+```
+
+## Replay ID
+
+When a replay capture begins, a Replay ID is generated by the SDK and is attached as an event property (`$mp_replay_id`) to events tracked by the SDK during the capture session. Events containing the same `$mp_replay_id` will appear in the same Replay.
+
+If you are sending any events not coming from the SDK, add the `$mp_replay_id` event property to attribute the event to a specific Replay.
+
+You can use the `getReplayId()` method to return the Replay ID for the current replay capture. The method will return an empty object if there is no active replay capture in progress.
+
+**Example Usage**
+
+```kotlin Kotlin
 // return the $mp_replay_id for the currently active capture
 MPSessionReplay.getInstance()?.getReplayId()
 // {$mp_replay_id: '19221397401184-063a51e0c3d58d-17525637-1d73c0-1919139740f185'}
 ```
 
-## Debug Mode
+### Logging
 
-No toggle is needed to enable debug logs; logging is always enabled in your developer/debug environment.
+Developers can enable or disable logging with the `enableLogging` option of the `MPSessionReplayConfig` object.
 
-## Replay Retention
+**Example Usage**
 
-User replays are stored for 30 days after the time of ingestion.
+```kotlin
+val config = MPSessionReplayConfig(wifiOnly = false, enableLogging = true)
+MPSessionReplay.initialize(token: token, distinctId: distinctId, config: config)
+```
+
+### Server-side Stitching
+
+Server-Side Stitching allows you to easily watch Replays for events that were not fired from the SDK.
+
+It works by inferring the Replay that an event belong using the Distinct ID and time property attached to the event. This is especially useful if you have events coming in from multiple sources.
+
+For example, let's say a user with Distinct ID "ABC" has a Replay recorded from 1-2pm. Two hours later, an event was sent from your warehouse with a timestamp of 1:35pm with Distinct ID "ABC". Server-Side Stitching will infer that the event should belong in the same Replay.
+
+To ensure Server-Side Stitching works, call [`identify()`](/docs/tracking-methods/sdks/android#identify) from the client-side using our SDK with the user's `$user_id`. This guarantees that events generated from both the client-side and server-side share the same Distinct ID. Learn more about [identifying users](/docs/tracking-methods/id-management).
+
+## Debugging
+
+<Callout type="info">
+`$mp_session_record` is exempt from your plan data allowance.
+</Callout>
+
+When a Replay capture begins, a "Session Recording Checkpoint" event will appear in your project, tracked as `$mp_session_record`. You may use this event to verify whether you have implemented Session Replay correctly.
+
+If you are using the [recommended sampling method](/docs/session-replay/implement-session-replay/session-replay-android#sampling) to capture your Replays but having trouble finding the Replays in your project, try calling `.startRecording()` manually and see if the `$mp_session_record` event appears. If it does appear but you are still struggling to locate your Replays, you may want to increase your sampling rate.
+
+You can also check the Home page for your project to check for any recent Replays listed in the "Latest Replays" card.
+
+If you are still struggling to implement, [submit a request to our Support team](https://mixpanel.com/get-support) for more assistance.
+
+## Privacy
+
+Mixpanel offers a privacy-first approach to Session Replay, including features such as data masking. Mixpanel's Session Replay privacy controls were designed to assist customers in protecting end user privacy. Read more [here](/docs/session-replay/session-replay-privacy-controls).
+
+### User Data
+
+The Mixpanel SDK will always mask all inputs. To protect end-user privacy, input text fields cannot be unmasked.
+
+By default, all text, images, and WebViews are also masked.
+
+You can unmask these element at your own discretion using the [`autoMaskedViews` config option described above](/docs/session-replay/implement-session-replay/session-replay-android#additional-configuration-options).
+
+Along with other data, the SDK respects all Do Not Track (DNT) settings as well as manual opt-out for any replay data. 
+
+### Retention
+
+By default, Mixpanel retains Session Replays for 30 days from the date the replay is ingested and becomes available for viewing within Mixpanel. Customers on our [Enterprise plan](https://mixpanel.com/pricing/) can customize this retention period between 7 days and 360 days. Once a replay is expired, there is no way to view that replay.
+
+### Legal (Beta Terms)
+
+Our Session Replay Beta Service Addendum can be found [here](https://mixpanel.com/legal/session-replay-beta-service-addendum/).
+
+The alpha and beta of Mixpanel's mobile session replay SDK will track certain events and send them to Mixpanel so that Mixpanel can understand and improve the alpha and beta mobile session replay feature experience. These events include starting and stopping a session, adding and removing sensitive classes, adding sensitive views and adding safe views. Nothing about your application will be included in this tracking; only your usage of the Mixpanel Session Replay SDK.
+
+## FAQ
+
+#### How does Session Replay work in Android?
+
+Session Replay observes user interactions within your app, capturing UI hierarchy changes and storing them as images, which are then sent to Mixpanel. Mixpanel reconstructs these images, applying recorded events as an end-user completes them. 
+
+Within Mixpanel's platform, you can view a reconstruction of your end-user's screen as they navigate your app. 
+
+However, Session Replay is not a literal video recording of your end-user's screen; end-user actions are not video-recorded.
+
+#### Can I prevent Session Replay from recording sensitive content?
+
+The Mixpanel SDK will always mask all inputs. By default, all text, images, and WebViews on a page.
+
+Additionally, you can customize how you leverage our SDK to fully control (1) where to record and (2) whom to record. Consider the [manual capture example scenarios](/docs/session-replay/implement-session-replay/session-replay-android#manual-capture), [SDK configuration options](/docs/session-replay/implement-session-replay/session-replay-android#additional-configuration-options), and [manual view masking example](/docs/session-replay/implement-session-replay/session-replay-android#mark-views-as-sensitive) provided above to customize the replay capture of your implementation.
+
+#### How can I estimate how many Replays I will generate?
+
+If you already use Mixpanel, the [Session Start events](/docs/features/sessions) are a way to estimate the rough amount of replays you might expect. This is especially true if you use timeout-based query sessions. However, because our sessions are defined at query time, we cannot guarantee these metrics will be directly correlated.
+
+When you enable Session Replay, use the above proxy metric to determine a starting sampling percentage, which will determine how many replays will be sent. You can always adjust this as you go to calibrate to the right level.
+
+#### How does Session Replay affect my app's bandwidth consumption?
+
+The bandwidth impact of Session Replay depends on the setting of the [`wifiOnly` parameter](/docs/session-replay/implement-session-replay/session-replay-android#additional-configuration-options).
+
+By default, `wifiOnly` is set to `true`, which means replay events are only flushed to the server when the device has a wifi connection. If there is no wifi, flushes are skipped, and the events remain in the in-memory queue until WiFi is restored. This ensures no additional cellular data is used, preventing users from incurring additional data charges.
+
+When `wifiOnly` is set to `false`, replay events are flushed with any available network connection, including cellular. In this case, the amount of cellular data consumed depends on the intensity of user interactions and the typical session length of your app. Users may incur additional data charges if large amounts of data are transmitted over cellular connections.
+
+#### How does Session Replay for mobile work if my app is offline?
+
+Session Replay for mobile does not work in offline mode.
+
+#### Does it work in XML/Jetpack Compose apps?
+
+Yes, standard XML-based apps are fully supported while Jetpack Compose apps have limited support for automatic masking of sensitive views. If your app is using Jetpack Compose, it is recommended that you manually mark your views as sensitive.
+
+#### Does it support Java based app?
+
+Yes, Java and Kotlin are fully interoperable.
+
+#### Does Mobile Session Replay work with my CDP?
+Yes — but only if the Mixpanel Session Replay SDK is installed client-side.
+
+Mobile Session Replay is compatible with CDPs like Segment and mParticle, but you must integrate the Mixpanel Session Replay SDK directly in your mobile app. Without it, replays won't be captured.
+
+Key Considerations:
+- If you're using Segment server-side, session replays will not be recorded, since the SDK isn't running in the app.
+- For Segment's client-side Analytics-Swift SDK, you can use Segment's Plugin Architecture to enrich events with the $mp_replay_id property, ensuring they're linked to their replays.
+- The Mixpanel Session Replay SDK is separate from the standard Mixpanel tracking SDK. You do not need the regular SDK, but the Replay SDK must be configured with a distinct_id and project token.
+- Events can be linked to replays either by:
+    - Manually attaching the current replay ID to each event
+    - Using server-side stitching after the fact
 
 ## Release History
 

--- a/pages/docs/tracking-methods/sdks/swift/swift-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/swift/swift-replay.mdx
@@ -2,16 +2,6 @@ import { Callout } from 'nextra/components'
 
 # Mixpanel Session Replay SDKs: Swift
 
-<Callout type="info">
-iOS Session Replay is currently in invite-only Private Beta. Please reach out to your Account Manager for any questions about Session Replay or iOS Beta access.
-</Callout>
-
-<Callout type="warning">
-Since our Beta program offers early access, some functionality, including data masking features, may contain bugs and cause crashes. We recommend thoroughly testing before enabling in production.
-
-Our Session Replay Beta Service Addendum can be found [here](https://mixpanel.com/legal/session-replay-beta-service-addendum/).
-</Callout>
-
 ## Getting started
 
 The Session Replay SDK for Swift is an supplementary SDK that complements the [main Swift SDK](/docs/tracking-methods/sdks/swift), enabling you to visually replay your users' app interactions through the [Session Replay](/docs/session-replay) feature. Please refer to our [developer guide on implementing Session Replay](/docs/session-replay/implement-session-replay/session-replay-ios) for a detailed walkthrough.
@@ -48,11 +38,12 @@ struct SessionReplayDemoApp: App {
         }
         .onChange(of: scenePhase) {
             if scenePhase == .active {
-                let config = MPSessionReplayConfig(wifiOnly: false, recordSessionsPercent: 100.0)
-                let sessionReplayInstance = MPSessionReplay.initialize(token: Mixpanel.mainInstance().apiToken, distinctId: Mixpanel.mainInstance().distinctId, config: config)
- 
-                sessionReplayInstance.loggingEnabled = true
-                sessionReplayInstance.startRecording()
+                let config = MPSessionReplayConfig(wifiOnly: false, enableLogging: true)
+                MPSessionReplay.initialize(
+                        token: Mixpanel.mainInstance().apiToken,
+                        distinctId: Mixpanel.mainInstance().distinctId,
+                        config: config
+                )
             }
         }
 }
@@ -72,24 +63,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
         Mixpanel.initialize(token: token, trackAutomaticEvents: true)
  
-        let config = MPSessionReplayConfig(
-            wifiOnly: false,
-            recordSessionsPercent: 100.0
-        )
-        let sesionReplayInstance = MPSessionReplay.initialize(
-            token: Mixpanel.mainInstance().apiToken,
-            distinctId: Mixpanel.mainInstance().distinctId,
-            config: config
-        )
-        #if DEBUG
         Mixpanel.mainInstance().loggingEnabled = true
-        MPSessionReplay.getInstance()?.loggingEnabled = true
-				#endif
-        return true
-    }
  
-    func applicationDidBecomeActive(_ application: UIApplication) {
-        MPSessionReplay.getInstance()?.startRecording()
+        let config = MPSessionReplayConfig(wifiOnly: false, enableLogging: true)
+        MPSessionReplay.initialize(
+                token: Mixpanel.mainInstance().apiToken,
+                distinctId: Mixpanel.mainInstance().distinctId,
+                config: config
+        )
     }
  
 }
@@ -98,80 +79,68 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 ## Capturing Replays
 
 <Callout type="warning">
-	Test in a sandbox project and start with a smaller sample rate. This allows you to monitor performance, usage, and ensure your privacy rules align with your company policies.
+	Test in a sandbox project and start with a lower sampling rate. This allows you to monitor performance, usage, and ensure your privacy rules align with your company policies.
 </Callout>
 
-You can capturing replay data using a sampling method (recommended), or customize when and where replays are captured manually using methods provided by the Session Replay Swift SDK.
+You can capture replay data using a sampling method (recommended), or customize when and where replays are captured manually using methods provided by the Session Replay Swift SDK.
 
 ### Sampling
 
-To enable Session Replay and set your sampling rate, use the [`SessionReplayConfig`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L26) object and set [`recordSessionsPercent`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L42) with a value between `0.0` and `100.0`. 
+We recommend using our sampling functionality unless you need custom logic to decide when to record sessions.
 
-At `0.0` no sessions will be recorded, at `100.0` all sessions will be recorded.
+To enable Session Replay and set your sampling rate, create a `MPSessionReplayConfig` object and set the `recordingSessionsPercent` with a value between `0.0` and `100.0`. At `0.0` no sessions will be recorded, at `100.0` (default) all sessions will be recorded.
+
+Start with a low sampling rate, then adjust according to your specific analytics needs.
+
+Upon initialization, recording starts automatically if the sampling check passes.
 
 **Example Usage**
 
 ```swift Swift
 // records 1% of all sessions
-MPSessionReplayConfig(recordSessionsPercent: 1.0)
+MPSessionReplayConfig(recordingSessionsPercent: 1.0)
 ```
 
-### Manual Capture
+### Manual Recording
 
 To programatically start and stop replay capture, use the `.startRecording()` and `.stopRecording()` methods.
 
-#### Start Recording
+#### Start Recording Replay Data
 
-Call [`.startRecording()`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift#L123) to force recording to begin, regardless of the `recordSessionsPercent` init option. 
+Calling `.startRecording()` will force recording to begin regardless of the `recordingSessionsPercent` sampling check.
 
-The recording automatically stops when the app goes to the background. Therefore, if you want to continuously record the replays, you will need to restart the replay once the app becomes active again.
+Recording automatically stops when the app goes into the background. If `autoStartRecording` is `true` (default) recording automatically re-starts when the app comes back to the foreground.
+
+Calling `.startRecording()` has no effect while recording is already in progress.
 
 **Example Usage**
 
 ```swift Swift
-// manually trigger a replay capture
+// manually force recording to begin for 100% of sessions
 MPSessionReplay.getInstance()?.startRecording()
-// no effect if recording is already in progress
 ```
 
-#### Stop Recording
+```swift Swift
+// manually force recording to begin with a 50% sampling rate
+MPSessionReplay.getInstance()?.startRecording(sessionsPercent: 50.0)
+```
 
-Call [`.stopRecording()`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift#L218) to stop any active replay data collection. The SDK automatically stops recording when the app goes to the background.
+#### Stop Recording Replay Data
+
+Call `.stopRecording()` to stop any active replay data collection. The SDK automatically stops recording when the app goes to the background.
+
+Calling `.stopRecording()` has no effect when there is no recording in progress.
 
 **Example Usage**
 
 ```swift Swift
 // manually end a replay capture
 MPSessionReplay.getInstance()?.stopRecording()
-// no effect if recording is not already in progress
-```
-
-### Config Options
-
-Upon initialization you can provide a [`SessionReplayConfig`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L26) object to customize your replay capture behavior.
-
-Currently, there are four config options:
-
-| Option | Description | Default | 
-| --- | --- | --- |
-| [`wifiOnly`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L34) | When `true`, replay events will only be flushed to the server when the device has a WiFi connection. If there is no wifi, flushes are skipped and the events remain in the in-memory queue until wifi is restored (or until the queue reaches its limit and the oldest events are evicted to make room for newer events). <br/> When `false`, replay events will be flushed with any network connection, including cellular. | `true` |
-| [`recordSessionsPercent`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L42) | This is a value between `0.0` and `100.0` that controls the sampling rate for recording session replays. <br/> At `0.0` no sessions will be recorded. At `100.0` all sessions will be recorded.  | `0.0` |
-| [`autoMaskedViews`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L47) | This is a `Set` of enum options for the types of views that should be masked by the SDK automatically. | `Image`, `Text`, and `Web` |
-| [`autoCapture`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L57) | This an enum to selectively disable the runtime method replacement functionality (aka “swizzling") in the event that it conflicts with another SDK (like [New Relic](https://docs.newrelic.com/docs/mobile-monitoring/new-relic-mobile-ios/get-started/new-relic-ios-compatibility-requirements/#method)) | `.enabled` |
-
-Note: automasking is supported for apps using UIKit. If you’re using SwiftUI, automasking is not yet fully supported. However, full masking functionality is still available through manual masking controls. We recommend developers test their implementations thoroughly to ensure sensitive data is properly masked.
-
-**Example Usage**
-
-```swift Swift
-// mask images only
-// only send recordings on wifi
-MPSessionReplayConfig(autoMaskedViews: [.Image], wifiOnly: true)
 ```
 
 #### Manual Screenshot Capture
 
-If you have partially or completely disabled automatic screen capture via the `autoCapture` config setting above, you can manually capture screenshots by calling [`.captureScreenshot()`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift#L151):
+You can also manually trigger the capture of individual screenshots by calling `.captureScreenshot()`:
 
 **Example Usage**
 
@@ -183,24 +152,91 @@ MPSessionReplay.getInstance()?.captureScreenshot()
 MPSessionReplay.getInstance()?.captureScreenshot(withTouchEvent: touchEvent)
 ```
 
-If you choose to disable auto capture and do manual screen capturing instead, it will be up to you to determine when, where and how you call the `.captureScreenshot()` method in your application. The most naïve approach would be to call it on a `Timer`.
+#### Example Use Cases for Manual Capture
+
+| Scenario | Guidance | 
+| --- | --- |
+| We have a sensitive screen we don't want to capture | When user is about to access the sensitive screen, call `.stopRecording()`. To resume recording once they leave this screen, you can resume recording with `.startRecording()`  | 
+| We only want to record certain types of users (e.g. Free plan users only) | Using your application code, determine if current user meets the criteria of users you wish to capture. If they do, then call `.startRecording()` to begin recording |
+| We only want to users utilizing certain features | When user is about to access the feature you wish to capture replays for, call `.startRecording()` to begin recording |
+
+### Additional Configuration Options
+
+Upon initialization you can provide a [`SessionReplayConfig`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/Models/MPSessionReplayConfig.swift#L26) object to customize your replay capture behavior.
+
+Currently, there are six config options:
+
+| Option | Description | Default | 
+| --- | --- | --- |
+| `wifiOnly` | When `true`, replay events will only be flushed to the server when the device has a WiFi connection. If there is no wifi, flushes are skipped and the events remain in the in-memory queue until wifi is restored (or until the queue reaches its limit and the oldest events are evicted to make room for newer events). <br/> When `false`, replay events will be flushed with any network connection, including cellular. | `true` |
+| `autoMaskedViews` | This is a `Set` of enum options for the types of views that should be masked by the SDK automatically. | `[.image, .text, .web, .map]` |
+| `autoStartRecording` | This is a boolean value that determines whether or not recording begins automatically upon initialization and when returning to the foreground. | `true` |
+| `recordingSessionsPercent` | This is a value between `0.0` and `100.0` (default) that controls the sampling rate for automatically triggered session replays. <br/> At `0.0` no sessions will be recorded. At `100.0` all sessions will be recorded.  | `100.0` |
+| `flushInterval` | Specifies the flush interval (in seconds) at which session replay events are sent to the Mixpanel server. | `10` |
+| `enableLogging` | This is a boolean value that determines whether or not debugging logs are printed to the console. | `false` |
+
+**autoMaskedViews Example Usage**
+```swift Swift
+// mask images only
+MPSessionReplayConfig(autoMaskedViews: [.image])
+
+// disable auto masking
+MPSessionReplayConfig(autoMaskedViews: [])
+```
+
+Alternatively:
+
+```swift Swift
+// mask images only
+MPSessionReplay.getInstance()?.autoMaskedViews = [.image]
+
+// disable auto masking
+MPSessionReplay.getInstance()?.autoMaskedViews = []
+```
+
+#### Identity Management
+
+The Mixpanel distinct ID for the current user can be passed into the initializer and changed at runtime by calling the `.identify(distinctId:)` method:
 
 **Example Usage**
 
 ```swift Swift
-// trigger manual screenshot capture using Timer
-let screenshotTimer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { _ in
-    MPSessionReplay.getInstance()?.captureScreenshot()
+// initialize the main Mixpanel tracking SDK
+Mixpanel.initialize(token: token, trackAutomaticEvents: true)
+
+// initialize the session replay SDK with the project token and distinct ID from above
+MPSessionReplay.initialize(
+        token: Mixpanel.mainInstance().apiToken,
+        distinctId: Mixpanel.mainInstance().distinctId,
+)
+```
+
+To change the distinct ID later:
+
+```swift Swift
+// for example when the user logs out
+func logout() {
+    // reset the main Mixpanel tracking SDK to generate a new distinct ID
+    Mixpanel.mainInstance().reset()
+    let newDistinctId = Mixpanel.mainInstance().getDistinctId()
+    // change session replay distinct ID
+    MPSessionReplay.getInstance()?.identify(distinctId: newDistinctId)
 }
 ```
 
-Keeping in mind that this is relatively inefficient and will result in capturing unnecessary/unchanged screenshots, it is also possible to miss important moments in between the timed screenshots.
+#### Manual Flushing
+
+You can flush any currently queued session replay events at any time by calling `.flush()`:
+
+```swift Swift
+MPSessionReplay.getInstance()?.flush()
+```
 
 ### Mark Views as Sensitive
 
-Mark any views as sensitive by setting `mpReplaySensitive` to `true`. Views marked as "sensitive" will be masked. 
+If your app is SwiftUI-based or UIKit-based, all `UITextField` and `UILabel` components are masked by default. `UITextField` cannot be unmasked, while `UILabels` can be unmasked
 
-Set `mpReplaySensitive` to `false` to mark any view as safe. Views marked as "safe" will not be masked.
+You can also mark any views as sensitive using `mpReplaySensitive`. Views marked as "sensitive" will always be masked.
 
 **Example Usage**
 
@@ -216,11 +252,29 @@ let ccView = CreditCardUIView()
 ccView.mpReplaySensitive = true
 ```
 
-All `UITextField` and `UILabel` components are masked by default. `UITextField` cannot be unmasked, while `UILabels` can be unmasked
+Set `mpReplaySensitive` to `false` to mark any view as "safe". Views marked as "safe" will never be masked.
 
-## Get Replay ID
+**Example Usage**
 
-Use the [`getReplayId()`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/2fb5c4651fa7bd661395082d5350565401ed26f7/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplay.swift#L19) method to return the [Replay ID](/docs/session-replay/implement-session-replay/session-replay-ios#replay-id) for the current replay recording. The method will return an empty object if there is no active replay capture in progress.
+```swift Swift
+// Mark any view as safe
+
+// SwiftUI
+BackgroundImage()
+    .mpReplaySensitive(false)
+ 
+//UIKit
+let bgImage = BackgroundImage()
+bgImage.mpReplaySensitive = false
+```
+
+## Replay ID
+
+When a replay capture begins, a Replay ID is generated by the SDK and is attached as an event property (`$mp_replay_id`) to events tracked by the Mixpanel SDK during the capture session. Events containing the same `$mp_replay_id` will appear in the same Replay.
+
+If you are sending any events not coming from the Mixpanel SDK, add the `$mp_replay_id` event property to attribute the event to a specific Replay.
+
+You can use the `getReplayId()` method to return the Replay ID for the current replay capture. The method will return an empty object if there is no active replay capture in progress.
 
 **Example Usage**
 
@@ -230,32 +284,131 @@ MPSessionReplay.getInstance()?.getReplayId()
 // {$mp_replay_id: '19221397401184-063a51e0c3d58d-17525637-1d73c0-1919139740f185'}
 ```
 
-## Flushing
+### Server-Side Stitching
 
-Use the [`flush()`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift#L255) method to manually flush replay events in queue.
+Server-Side Stitching allows you to easily watch Replays for events that were not fired from the SDK.
 
-```swift Swift
-// trigger manual flushing for replay events
-MPSessionReplay.getInstance()?.flush()
-```
+It works by inferring the Replay that an event belong using the Distinct ID and time property attached to the event. This is especially useful if you have events coming in from multiple sources.
 
-## Debug Mode
+For example, let's say a user with Distinct ID "ABC" has a Replay recorded from 1-2pm. Two hours later, an event was sent from your warehouse with a timestamp of 1:35pm with Distinct ID "ABC". Server-Side Stitching will infer that the event should belong in the same Replay.
 
-Enable or disable logging with the [`loggingEnabled`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift#L52) property of the [`MPSessionReplay`](https://github.com/mixpanel/mixpanel-ios-session-replay/blob/e3d9edd6c68fc027b5217ef42dd2bd0234b8262e/MixpanelSessionReplay/MixpanelSessionReplay/MPSessionReplayInstance.swift) object.
+To ensure Server-Side Stitching works, call [`identify()`](/docs/tracking-methods/sdks/swift#identify) from the client-side using our SDK with the user's `$user_id`. This guarantees that events generated from both the client-side and server-side share the same Distinct ID. Learn more about [identifying users](/docs/tracking-methods/id-management).
+
+## Debugging
+
+<Callout type="info">
+`$mp_session_record` is exempt from your plan data allowance.
+</Callout>
+
+When a Replay capture begins, a "Session Recording Checkpoint" event will appear in your project, tracked as `$mp_session_record`. You may use this event to verify whether you have implemented Session Replay correctly.
+
+If you are using the [recommended sampling method](/docs/session-replay/implement-session-replay/session-replay-ios#sampling) to capture your Replays but having trouble finding the Replays in your project, try calling `.startRecording()` manually and see if the `$mp_session_record` event appears. If it does appear but you are still struggling to locate your Replays, you may want to increase your sampling rate.
+
+You can also check the Home page for your project to check for any recent Replays listed in the "Latest Replays" card.
+
+If you are still struggling to implement, [submit a request to our Support team](https://mixpanel.com/get-support) for more assistance.
+
+### Logging
+
+Developers can enable or disable logging with the `enableLogging` option of the `MPSessionReplayConfig` object or via the `loggingEnabled` property of the main `MPSessionReplay` instance.
 
 **Example Usage**
 
 ```swift Swift
 let token = Mixpanel.mainInstance().apiToken
 let distinctId = Mixpanel.mainInstance().distinctId
-let config = MPSessionReplayConfig(wifiOnly: false, recordSessionsPercent: 50.0)
-let sessionReplayInstance = MPSessionReplay.initialize(token: token, distinctId: distinctId, config: config)
-sessionReplayInstance.loggingEnabled = true // enable debug log
+let config = MPSessionReplayConfig(wifiOnly: false, enableLogging: true) // enable debug logging
+MPSessionReplay.initialize(token: token, distinctId: distinctId, config: config)
 ```
 
-## Replay Retention
+Alternatively:
+
+```swift Swift
+MPSessionReplay.getInstance()?.loggingEnabled = true
+```
+
+## Privacy
+
+Mixpanel offers a privacy-first approach to Session Replay, including features such as data masking. Mixpanel's Session Replay privacy controls were designed to assist customers in protecting end user privacy. Read more [here](/docs/session-replay/session-replay-privacy-controls).
+
+### User Data
+
+The Mixpanel SDK will always mask all input text fields. To protect end-user privacy, input text fields cannot be unmasked.
+
+By default, all text, images, WKWebViews and MKMapViews are also masked.
+
+You can unmask these elements at your own discretion using the [`autoMaskedViews` config option described above](/docs/session-replay/implement-session-replay/session-replay-ios#additional-configuration-options).
+
+### Retention
 
 By default, Mixpanel retains Session Replays for 30 days from the date the replay is ingested and becomes available for viewing within Mixpanel. Customers on our [Enterprise plan](https://mixpanel.com/pricing/) can customize this retention period between 7 days and 360 days. Once a replay is expired, there is no way to view that replay.
+
+### Legal (Beta Terms)
+
+Our Session Replay Beta Service Addendum can be found [here](https://mixpanel.com/legal/session-replay-beta-service-addendum/).
+
+The alpha and beta of Mixpanel's mobile session replay SDK will track certain events and send them to Mixpanel so that Mixpanel can understand and improve the alpha and beta mobile session replay feature experience. These events include starting and stopping a session, adding and removing sensitive classes, adding sensitive views and adding safe views. Nothing about your application will be included in this tracking; only your usage of the Mixpanel Session Replay SDK.
+
+## FAQ
+
+#### How does Session Replay work in iOS?
+
+Session Replay observes user interactions within your app, capturing UI hierarchy changes and storing them as images, which are then sent to Mixpanel. Mixpanel reconstructs these images, applying recorded events as an end-user completes them. 
+
+Within Mixpanel's platform, you can view a reconstruction of your end-user's screen as they navigate your app. 
+
+However, Session Replay is not a literal video recording of your end-user's screen; end-user actions are not video-recorded.
+
+#### Can I prevent Session Replay from recording sensitive content?
+
+The Mixpanel SDK will always mask all inputs. By default, all text, images, and WebViews on a page.
+
+Additionally, you can customize how you leverage our SDK to fully control (1) where to record and (2) whom to record. Consider the [manual capture example scenarios](/docs/session-replay/implement-session-replay/session-replay-ios#manual-capture), [SDK configuration options](/docs/session-replay/implement-session-replay/session-replay-ios#additional-configuration-options), and [manual view masking example](/docs/session-replay/implement-session-replay/session-replay-ios#mark-views-as-sensitive) provided above to customize the replay capture of your implementation.
+
+#### How can I estimate how many Replays I will generate?
+
+If you already use Mixpanel, the [Session Start events](/docs/features/sessions) are a way to estimate the rough amount of replays you might expect. This is especially true if you use timeout-based query sessions. However, because our sessions are defined at query time, we cannot guarantee these metrics will be directly correlated.
+
+When you enable Session Replay, use the above proxy metric to determine a starting sampling percentage, which will determine how many replays will be sent. You can always adjust this as you go to calibrate to the right level.
+
+#### How does Session Replay affect my app's performance?
+
+There is no impact on your app's performance when there are no user interactions or nothing changes on the screen. When there are user interactions, we expect negligible impact on CPU usage and memory consumption. There is no impact on disk I/O because Session Replay does not write anything to your disk. 
+
+In our own testing, the overhead is unnoticeable, however this testing was not exhaustive, and you may discover the recording overhead may negatively impact your mobile application performance depending on your application specifications. If you experience any performance degradations after installing Session Replay, please [reach out to our Support team](https://mixpanel.com/get-support).
+
+#### How Does Session Replay affect my app's bandwidth consumption?
+
+The bandwidth impact of Session Replay depends on the setting of the [`wifiOnly` parameter](/docs/session-replay/implement-session-replay/session-replay-ios#additional-configuration-options).
+
+By default, `wifiOnly` is set to `true`, which means replay events are only flushed to the server when the device has a wifi connection. If there is no wifi, flushes are skipped, and the events remain in the in-memory queue until WiFi is restored. This ensures no additional cellular data is used, preventing users from incurring additional data charges.
+
+When `wifiOnly` is set to `false`, replay events are flushed with any available network connection, including cellular. In this case, the amount of cellular data consumed depends on the intensity of user interactions and the typical session length of your app. Users may incur additional data charges if large amounts of data are transmitted over cellular connections.
+
+#### How does Session Replay for mobile work if my app is offline?
+
+Session Replay for mobile does not work in offline mode.
+
+#### Does it work in SwiftUI/UIKit apps?
+
+[Yes.](/docs/session-replay/implement-session-replay/session-replay-ios#initialize)
+
+#### Does it support Obj-C based app?
+
+Yes, Objective-C and Swift are fully interoperable.
+
+#### Does Mobile Session Replay work with my CDP?
+Yes — but only if the Mixpanel Session Replay SDK is installed client-side.
+
+Mobile Session Replay is compatible with CDPs like Segment and mParticle, but you must integrate the Mixpanel Session Replay SDK directly in your mobile app. Without it, replays won't be captured.
+
+Key Considerations:
+- If you're using Segment server-side, session replays will not be recorded, since the SDK isn't running in the app.
+- For Segment's client-side Analytics-Swift SDK, you can use Segment's Plugin Architecture to enrich events with the $mp_replay_id property, ensuring they're linked to their replays.
+- The Mixpanel Session Replay SDK is separate from the standard Mixpanel tracking SDK. You do not need the regular SDK, but the Replay SDK must be configured with a distinct_id and project token.
+- Events can be linked to replays either by:
+    - Manually attaching the current replay ID to each event
+    - Using server-side stitching after the fact
 
 ## Release History
 

--- a/pages/docs/tracking-methods/sdks/swift/swift-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/swift/swift-replay.mdx
@@ -343,12 +343,6 @@ You can unmask these elements at your own discretion using the [`autoMaskedViews
 
 By default, Mixpanel retains Session Replays for 30 days from the date the replay is ingested and becomes available for viewing within Mixpanel. Customers on our [Enterprise plan](https://mixpanel.com/pricing/) can customize this retention period between 7 days and 360 days. Once a replay is expired, there is no way to view that replay.
 
-### Legal (Beta Terms)
-
-Our Session Replay Beta Service Addendum can be found [here](https://mixpanel.com/legal/session-replay-beta-service-addendum/).
-
-The alpha and beta of Mixpanel's mobile session replay SDK will track certain events and send them to Mixpanel so that Mixpanel can understand and improve the alpha and beta mobile session replay feature experience. These events include starting and stopping a session, adding and removing sensitive classes, adding sensitive views and adding safe views. Nothing about your application will be included in this tracking; only your usage of the Mixpanel Session Replay SDK.
-
 ## FAQ
 
 #### How does Session Replay work in iOS?


### PR DESCRIPTION
This pull request updates documentation for implementing Session Replay in iOS and Android SDKs, focusing on renaming configuration properties, improving clarity, and simplifying integration steps. It also removes outdated references to beta terms and updates installation instructions for the Android SDK.

### Updates to Session Replay Configuration Properties:

- **iOS Documentation**:
  - Renamed `autoStartRecordingSessionsPercent` to `recordingSessionsPercent` for clarity in sampling rate configuration. [[1]](diffhunk://#diff-22e1938fa50245227c39da84cb1490062505e766db5fe4aa8389d26075bde302L90-R90) [[2]](diffhunk://#diff-22e1938fa50245227c39da84cb1490062505e766db5fe4aa8389d26075bde302L100-R100) [[3]](diffhunk://#diff-22e1938fa50245227c39da84cb1490062505e766db5fe4aa8389d26075bde302L109-R109) [[4]](diffhunk://#diff-22e1938fa50245227c39da84cb1490062505e766db5fe4aa8389d26075bde302L123-R123) [[5]](diffhunk://#diff-22e1938fa50245227c39da84cb1490062505e766db5fe4aa8389d26075bde302L172-R172)

- **Android Documentation**:
  - Renamed `recordSessionsPercent` to `recordingSessionsPercent` for consistency across platforms.

### Improvements to Android SDK Integration:

- Updated installation instructions to use Maven Central instead of manually embedding AAR files, simplifying setup.
- Added guidance on configuring `autoStartRecording` and clarified behavior for manual replay capture methods.

### Removal of Outdated Content:

- Removed references to the Session Replay Beta Service Addendum and alpha/beta tracking events from iOS documentation.
- Removed the Android Private Alpha Callout and replaced outdated installation steps.

### Enhancements to Android SDK Configuration Options:

- Added `enableLogging` as a configuration option and updated example usage to reflect this addition.
- Clarified masking behavior for `TextView` and `EditText` components and provided examples for customizing `autoMaskedViews`.