### PR TITLE
Upgrade to node 20

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,10 @@
         "tailwindcss": "3.4.14",
         "typescript": "5.8.3",
         "yaml": "2.8.0"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <12.0.0"
       }
     },
     "node_modules/@75lb/deep-merge": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "url": "https://github.com/mixpanel/docs/issues"
   },
   "homepage": "https://github.com/mixpanel/docs#readme",
+  "engines": {
+    "node": ">=20.0.0 <21.0.0",
+    "npm": ">=10.0.0 <12.0.0"
+  },
   "dependencies": {
     "@docsearch/js": "3.9.0",
     "@docsearch/react": "3.9.0",


### PR DESCRIPTION
Since v18 is deprecated and Vercel will kick us out by September 1