### PR TITLE
[DINO-53] Remove sync toggle from JSON pipeline creation UI

### DIFF
--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -106,20 +106,21 @@ Removed sync toggle from JSON pipeline creation UI. All new JSON pipelines now h
 </details>
 
 <details>
-<summary><strong>2025-08-14 (US): Pipeline System Improvements By Incremental Export</strong></summary>
+<summary><strong>2025-08-14: Incremental Export Deployed for US Pipelines</strong></summary>
  
 We have deployed the Incremental Export Improvement for newly created pipelines with US data residency.
 
-The rollout of these updates to existing pipelines in all regions is scheduled for the near future. 
-Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same; only the processing method has improved.
+The rollout of these updates to existing pipelines in US residency is scheduled for the near future.
+Your pipeline will automatically transition to the new system when ready.
+Your data quality and completeness remain the same; only the processing method has improved.
 
 You can find out more about Incremental Export in the previous changelog below (2025-06-26).
 </details>
 
 <details>
-<summary><strong>2025-06-26: Pipeline System Improvements By Incremental Export</strong></summary>
+<summary><strong>2025-06-26: Introducing Incremental Export for Event Pipelines</strong></summary>
 
-We're rolling out an improved pipeline system to improve the efficiency and reliability of your data exports. We're deploying these improvements gradually across all customers, starting with new pipelines in our EU and IN data residency. New pipelines in projects with US residency and existing pipelines in all regions will follow after. Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same - only the processing method has improved.
+We're rolling out an improved pipeline system to improve the efficiency and reliability of your data exports. We're deploying these improvements for newly created pipelines in our EU and IN data residency. New pipelines in projects with US residency and migrating existing pipelines in all regions will follow after. Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same - only the processing method has improved.
 
 **What is affected?**
 

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -94,32 +94,9 @@ Note: Use the `resolved_distinct_id` from the identity mappings table instead of
 
 Examples of querying the identity mapping table are available for [BigQuery](/docs/data-pipelines/integrations/bigquery#query-identity-mappings) and [Snowflake](/docs/data-pipelines/integrations/snowflake#query-identity-mappings).
 
-## Change Log
+## Incremental Pipelines
 
-<details>
-<summary><strong>2025-09-29: Sync Enabled by Default for JSON Pipelines</strong></summary>
-
-Removed sync toggle from JSON pipeline creation UI. All new JSON pipelines now have incremental sync enabled by default to ensure data consistency without requiring manual configuration.
-
-**Impact**: New JSON pipelines automatically include sync functionality - no longer optional through UI toggle.
-</details>
-
-<details>
-<summary><strong>2025-08-14: Incremental Export Deployed for US Pipelines</strong></summary>
- 
-We have deployed the Incremental Export Improvement for newly created pipelines with US data residency.
-
-The rollout of these updates to existing pipelines in US residency is scheduled for the near future.
-Your pipeline will automatically transition to the new system when ready.
-Your data quality and completeness remain the same; only the processing method has improved.
-
-You can find out more about Incremental Export in the previous changelog below (2025-06-26).
-</details>
-
-<details>
-<summary><strong>2025-06-26: Introducing Incremental Export for Event Pipelines</strong></summary>
-
-We're rolling out an improved pipeline system to improve the efficiency and reliability of your data exports. We're deploying these improvements for newly created pipelines in our EU and IN data residency. New pipelines in projects with US residency and migrating existing pipelines in all regions will follow after. Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same - only the processing method has improved.
+As of 10 September 2025, all JSON pipelines in all regions (US/EU/IN) have been migrated to our improved incremental pipeline export system.
 
 **What is affected?**
 
@@ -150,3 +127,29 @@ The sync feature is designed for events to keep the exported data up-to-date wit
 GDPR deletions do not automatically cascade deletions to data warehouses via pipelines. When a user is deleted from Mixpanel via the GDPR deletion API, this deletion is reflected in Mixpanel’s own storage, but the deletion does not propagate to data that has already been exported to data warehouses via pipelines.
 
 To keep your synced warehouse data GDPR compliant, you will need to implement a process to delete the corresponding user and event data from your warehouse when a GDPR deletion occurs in Mixpanel.
+
+## Change Log
+
+<details>
+<summary><strong>2025-09-29: Sync Enabled by Default for JSON Pipelines</strong></summary>
+
+Removed sync toggle from JSON pipeline creation UI. All new JSON pipelines now have incremental sync enabled by default to ensure data consistency without requiring manual configuration.
+
+**Impact**: New JSON pipelines automatically include sync functionality - no longer optional through UI toggle.
+</details>
+
+<details>
+<summary><strong>2025-08-14: Incremental Export Deployed for US Pipelines</strong></summary>
+ 
+We have deployed the Incremental Export Improvement for newly created pipelines with US data residency.
+
+The rollout of these updates to existing pipelines in US residency is scheduled for the near future.
+Your pipeline will automatically transition to the new system when ready.
+Your data quality and completeness remain the same; only the processing method has improved.
+</details>
+
+<details>
+<summary><strong>2025-06-26: Introducing Incremental Export for Event Pipelines</strong></summary>
+
+We're rolling out an improved pipeline system to improve the efficiency and reliability of your data exports. We're deploying these improvements for newly created pipelines in our EU and IN data residency. New pipelines in projects with US residency and migrating existing pipelines in all regions will follow after. Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same - only the processing method has improved.
+</details>

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -58,17 +58,15 @@ The following are examples of the output in **BigQuery** for each data source pi
 
 ## Events Data Sync
 
-> Sync is disabled by default when creating events pipelines. You can enable it by toggling it in the **Advanced** session.
+Events Data Sync is enabled by default when creating JSON pipelines to ensure data consistency. This feature automatically detects data changes as soon as they are ingested and appends new files for new/late data to your storage/warehouses, helping keep the data fresh and minimizing missing data points.
 
-Event data stored in Mixpanel’s datastore and in the export destination can fall out of sync.
-
-The discrepancy can be attributed to several different causes:
+Event data can fall out of sync between Mixpanel's datastore and the export destination due to several causes:
 
 - Late data can arrive multiple days later due to a mobile client being offline.
 - The import API can add data to previous days.
 - Delete requests related to GDPR can cause deletion of events and event properties.
 
-Mixpanel is able to detect any changes in your data as soon as they are ingested and adds new files for new/late data in object storage and data warehouse, if applicable. Data sync helps keep the data fresh and minimizes missing data points.
+**Important limitations**: Data sync does not fully guarantee syncing GDPR Data Deletions and will only sync data for days up to 10 days in the past. It is recommended to implement a strategy to remove all records of GDPR Deleted Users in your data warehouse. Additionally, we start checking for late arriving data 24 hours after the data for a day is exported. It may take more than 2 days for the data in the destination to be in sync with the data in Mixpanel.
 
 ## Backfill Historical Events
 
@@ -99,6 +97,29 @@ Examples of querying the identity mapping table are available for [BigQuery](/do
 ## Incremental Pipelines
 
 As of 10 September 2025, all JSON pipelines in all regions (US/EU/IN) have been migrated to our improved incremental pipeline export system.
+<details>
+<summary><strong>2025-09-27: Sync Enabled by Default for JSON Pipelines</strong></summary>
+
+Removed sync toggle from JSON pipeline creation UI. All new JSON pipelines now have incremental sync enabled by default to ensure data consistency without requiring manual configuration.
+
+**Impact**: New JSON pipelines automatically include sync functionality - no longer optional through UI toggle.
+</details>
+
+<details>
+<summary><strong>2025-08-14 (US): Pipeline System Improvements By Incremental Export</strong></summary>
+ 
+We have deployed the Incremental Export Improvement for newly created pipelines with US data residency.
+
+The rollout of these updates to existing pipelines in all regions is scheduled for the near future. 
+Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same; only the processing method has improved.
+
+You can find out more about Incremental Export in the previous changelog below (2025-06-26).
+</details>
+
+<details>
+<summary><strong>2025-06-26: Pipeline System Improvements By Incremental Export</strong></summary>
+
+We're rolling out an improved pipeline system to improve the efficiency and reliability of your data exports. We're deploying these improvements gradually across all customers, starting with new pipelines in our EU and IN data residency. New pipelines in projects with US residency and existing pipelines in all regions will follow after. Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same - only the processing method has improved.
 
 **What is affected?**
 

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -94,9 +94,8 @@ Note: Use the `resolved_distinct_id` from the identity mappings table instead of
 
 Examples of querying the identity mapping table are available for [BigQuery](/docs/data-pipelines/integrations/bigquery#query-identity-mappings) and [Snowflake](/docs/data-pipelines/integrations/snowflake#query-identity-mappings).
 
-## Incremental Pipelines
+## Change Log
 
-As of 10 September 2025, all JSON pipelines in all regions (US/EU/IN) have been migrated to our improved incremental pipeline export system.
 <details>
 <summary><strong>2025-09-29: Sync Enabled by Default for JSON Pipelines</strong></summary>
 

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -66,7 +66,7 @@ Event data can fall out of sync between Mixpanel's datastore and the export dest
 - The import API can add data to previous days.
 - Delete requests related to GDPR can cause deletion of events and event properties.
 
-**Important limitations**: Data sync does not fully guarantee syncing GDPR Data Deletions and will only sync data for days up to 10 days in the past. It is recommended to implement a strategy to remove all records of GDPR Deleted Users in your data warehouse. Additionally, we start checking for late arriving data 24 hours after the data for a day is exported. It may take more than 2 days for the data in the destination to be in sync with the data in Mixpanel.
+**Important limitations**: Data sync does not guarantee syncing GDPR Data Deletions. It is recommended to implement a strategy to remove all records of GDPR Deleted Users in your data warehouse.
 
 ## Backfill Historical Events
 

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -98,7 +98,7 @@ Examples of querying the identity mapping table are available for [BigQuery](/do
 
 As of 10 September 2025, all JSON pipelines in all regions (US/EU/IN) have been migrated to our improved incremental pipeline export system.
 <details>
-<summary><strong>2025-09-27: Sync Enabled by Default for JSON Pipelines</strong></summary>
+<summary><strong>2025-09-29: Sync Enabled by Default for JSON Pipelines</strong></summary>
 
 Removed sync toggle from JSON pipeline creation UI. All new JSON pipelines now have incremental sync enabled by default to ensure data consistency without requiring manual configuration.
 


### PR DESCRIPTION
This PR updates the JSON pipelines documentation to reflect that the sync toggle has been removed from the UI and sync is now enabled by default for all new JSON pipelines.
- Removed blockquote about sync being disabled by default and toggle in Advanced settings
- Updated description to explain sync is enabled by default for data consistency
- Added 2025-09-27 changelog entry documenting the sync toggle removal
- Improved formatting and removed redundant explanations

Also twist the previous change logs