### PR TITLE
Updated pipelines documentation 

### DIFF
--- a/pages/docs/data-pipelines.mdx
+++ b/pages/docs/data-pipelines.mdx
@@ -99,6 +99,10 @@ Mixpanel offers a 30-day free trial of the Data Pipelines, allowing you to creat
 - Only one pipeline can be created per data source per project.
 - Backfilled data is limited to one day prior to the creation date of the pipeline.
 
+### Why can’t I delete my trial pipeline?
+
+You can’t delete a trial pipeline in Mixpanel — this is intentional. Each project is limited to one trial pipeline per data source, and keeping it prevents deleting/recreating trials to bypass limits. It also serves as a record that the trial has been used. Even after you upgrade to a paid Data Pipelines package, the trial pipeline remains visible and cannot be removed. This is a policy decision to preserve the integrity of the trial program, not a technical constraint.
+
 ### What is Active Pipeline Limit
 
 Each project can have 2 recurring pipelines and 1 date ranged backfill pipeline active.

--- a/pages/docs/data-pipelines.mdx
+++ b/pages/docs/data-pipelines.mdx
@@ -105,9 +105,11 @@ Each project can have 2 recurring pipelines and 1 date ranged backfill pipeline 
 
 To maintain optimal performance across our services, we limit the number of concurrently running pipeline steps to one per project. This approach ensures that each job, including those involving substantial backfills, waits its turn, preventing any single project from monopolizing resources and thus promoting fair scheduling among all customers.
 
-### When do pipeline exports run?
+### Is it possible to specify when pipeline exports run?
 
-Pipelines by default are set to start an export 30 minutes after the time period to export in project time is complete. For example a project in the Pacific timezone with a daily events pipeline will start the export for data from 5/22 on 5/23 00:30 AM PT.
+No. Hourly pipelines are targeted to run 30 minutes past the hour to be exported, and daily pipelines are targeted to run 30 minutes past the day to be exported (e.g. 00:30 AM) in the project’s timezone. For example, a project in the Pacific timezone with a daily events pipeline will start the export for data from 5/22 on 5/23 00:30 AM PT.
+
+Please note that the [24-hour SLA](/docs/data-pipelines#what-is-the-service-level-agreement) applies.
 
 ### What is the Service Level Agreement?
 

--- a/pages/docs/data-pipelines/json-pipelines.mdx
+++ b/pages/docs/data-pipelines/json-pipelines.mdx
@@ -98,39 +98,24 @@ Note: Use the `resolved_distinct_id` from the identity mappings table instead of
 
 Examples of querying the identity mapping table are available for [BigQuery](/docs/data-pipelines/integrations/bigquery#query-identity-mappings) and [Snowflake](/docs/data-pipelines/integrations/snowflake#query-identity-mappings).
 
-## Change Log
+## Incremental Pipelines
 
-<details>
-<summary><strong>2025-08-14 (US): Pipeline System Improvements By Incremental Export</strong></summary>
- 
-We have deployed the Incremental Export Improvement for newly created pipelines with US data residency.
-
-The rollout of these updates to existing pipelines in all regions is scheduled for the near future. 
-Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same; only the processing method has improved.
-
-You can find out more about Incremental Export in the previous changelog below (2025-06-26).
-</details>
-
-<details>
-<summary><strong>2025-06-26: Pipeline System Improvements By Incremental Export</strong></summary>
-
-We're rolling out an improved pipeline system to improve the efficiency and reliability of your data exports. We're deploying these improvements gradually across all customers, starting with new pipelines in our EU and IN data residency. New pipelines in projects with US residency and existing pipelines in all regions will follow after. Your pipeline will automatically transition to the new system when ready. Your data quality and completeness remain the same - only the processing method has improved.
+As of 10 September 2025, all JSON pipelines in all regions (US/EU/IN) have been migrated to our improved incremental pipeline export system.
 
 **What is affected?**
 
-- **Events Pipelines with Sync Enabled Only**: This improvement only affects event pipelines that have sync enabled. People and identity mapping pipelines remain unchanged.
+- **Events pipelines with sync enabled only**: This improvement only affects event pipelines that have sync enabled. People and identity mapping pipelines remain unchanged.
 
 **Benefits**
 
-- **Elimination of data sync delays** - no more waiting for daily sync processes to detect and fix data discrepancies
-- **Complete data export** - all events are exported without the risk of missing late-arriving data. Late-arriving events are automatically exported regardless of how late they arrive, eliminating the previous 10-day sync window restriction
+- **Elimination of data sync delays**: No more waiting for daily sync processes to detect and fix data discrepancies.
+- **Complete data export**: All events are exported without the risk of missing late-arriving data. Late-arriving events are automatically exported regardless of how late they arrive, eliminating the previous 10-day sync window restriction.
 
-**Changes You May Notice**
+**Changes you may notice**
 
-- **Event Count Display**: The event count shown per task in the UI now represents the total events processed per batch rather than events exported per day or per hour. Since each batch can span multiple days, this number may appear different from before.
-- **Backfill Process**: When a new pipeline is created, it will complete the full historical backfill first before starting regular processing. For example, if you create a pipeline on January 15th at 11 AM with a backfill from January 1st, the system will first export all events that arrived in Mixpanel before around January 15th 11 AM as the initial backfill, then begin processing any new events that arrive after around January 15th 11 AM, regardless of which date those events are for. Existing pipelines will have the last 10 days backfilled as part of the migration and then the new incremental behavior will start.
-- **Storage Location File Structure Changes**: Previous behavior of sync would replace files for a day when the day was re-synced. No sync means Mixpanel will no longer coalesce files for days when sync runs so files are no longer updated/removed. Incremental pipelines will instead add a new file with events seen in each day for each run of the pipeline meaning more small files are expected.
-- **Pipelines Logs Reset**: Once your pipeline is migrated the logging available in th UI will be reset so past jobs log lines will no longer available. Only the new incremental jobs will be visible going forward.
-- **Predicable Deletion Behavior**:  In rare cases the sync functionality meant that Mixpanel could re-sync days for which data was deleted allowing the pipeline to also remove that data from your data warehouse. Sync keeping your warehouse in line with deletions was not guaranteed behavior however. The removal of sync means this unreliable behavior has been removed and as such warehouse data owners are responsible for the deletion of all data on the warehouse side.
-- **More Pre-shuffled Distinct Ids in Data**: The faster export and removal of late syncs for data can lead to more events exported with their original distinct_id as opposed to the resolved identifier seen in Mixpanel after we’ve shuffled the data. These discrepancies are expected in pipelines on both the old and new behavior and can be resolved using the ID mappings table exported from identity pipelines outlined in [our docs here](docs/data-pipelines/json-pipelines#user-identity-resolution).
-</details>
+- **Event count display**: The event count shown per task in the UI now represents the total events processed per batch rather than events exported per day or per hour. Since each batch can span multiple days, this number may appear different from before.
+- **Backfill process**: When a new pipeline is created, it will complete the full historical backfill first before starting regular processing. For example, if you create a pipeline on January 15th at 11 AM with a backfill from January 1st, the system will first export all events that arrived in Mixpanel before around January 15th 11 AM as the initial backfill, then begin processing any new events that arrive after around January 15th 11 AM, regardless of which date those events are for. Existing pipelines will have the last 10 days backfilled as part of the migration and then the new incremental behavior will start.
+- **Storage location file structure changes**: Previous behavior of sync would replace files for a day when the day was re-synced. No sync means Mixpanel will no longer coalesce files for days when sync runs so files are no longer updated/removed. Incremental pipelines will instead add a new file with events seen in each day for each run of the pipeline meaning more small files are expected.
+- **Pipelines logs reset**: Once your pipeline is migrated, the logging available in the UI will be reset so past jobs log lines will no longer be available. Only the new incremental jobs will be visible going forward.
+- **Predicable deletion behavior**:  In rare cases, the sync functionality meant that Mixpanel could re-sync days for which data was deleted, allowing the pipeline to also remove that data from your data warehouse. Sync keeping your warehouse in line with deletions was not guaranteed behavior however. The removal of sync means this unreliable behavior has been removed and as such, warehouse data owners are responsible for the deletion of all data on the warehouse side.
+- **More pre-shuffled distinct IDs in data**: The faster export and removal of late syncs for data can lead to more events exported with their original `distinct_id` as opposed to the resolved identifier seen in Mixpanel after we’ve shuffled the data. These discrepancies are expected in pipelines on both the old and new behavior, and can be resolved using the ID mappings table exported from identity pipelines outlined in [our docs here](/docs/data-pipelines/json-pipelines#user-identity-resolution).


### PR DESCRIPTION
- Added a bit more detail on when pipelines are scheduled to run.
- Added an FAQ on "Why can’t I delete my trial pipeline?"
- Removed the changelog entirely and moved the explanation about incremental pipelines into the main documentation with minor wording changes.