### PR TITLE
Update go, node, python docs for flags

### DIFF
--- a/pages/docs/featureflags.mdx
+++ b/pages/docs/featureflags.mdx
@@ -245,7 +245,7 @@ See our developer guides on implementing feature flags on these platforms below:
   <Cards.Card icon title="Ruby (Beta)" href="/docs/tracking-methods/sdks/ruby/ruby-flags" />
   <Cards.Card icon title="Node.js" href="/docs/tracking-methods/sdks/nodejs/nodejs-flags" />
   <Cards.Card icon title="Java" href="/docs/tracking-methods/sdks/java/java-flags" />
-  <Cards.Card icon title="Go (Beta)" href="/docs/tracking-methods/sdks/go/go-flags" />
+  <Cards.Card icon title="Go" href="/docs/tracking-methods/sdks/go/go-flags" />
 </Cards>
 
 <Callout type="info">

--- a/pages/docs/tracking-methods/sdks/go/go-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/go/go-flags.mdx
@@ -10,10 +10,10 @@ This developer guide will assist you in configuring your server-side Go platform
 
 Before implementing [Feature Flags](/docs/featureflags), ensure:
 
-- You are on an Enterprise subscription plan and have the [Mixpanel Go SDK](https://github.com/mixpanel/mixpanel-go) installed. If not, please follow [this doc](/docs/quickstart/install-mixpanel) to install the SDK. The minimum supported version is [`v2.0.0-beta.1`](https://github.com/mixpanel/mixpanel-go/releases/tag/v2.0.0-beta.1)
+- You are on an Enterprise subscription plan and have the [Mixpanel Go SDK](https://github.com/mixpanel/mixpanel-go) installed. If not, please follow [this doc](/docs/quickstart/install-mixpanel) to install the SDK. The minimum supported version is [`v2.0.0`](https://github.com/mixpanel/mixpanel-go/releases/tag/v2.0.0)
 
 ```bash
-go get github.com/mixpanel/mixpanel-go@v2.0.0-beta.1
+go get github.com/mixpanel/mixpanel-go@v2.0.0
 ```
 
 - You have your Project Token from your [Mixpanel Project Settings](/docs/orgs-and-projects/managing-projects#find-your-project-tokens)
@@ -118,7 +118,7 @@ func main() {
 		},
 	}
 
-	mp := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithRemoteFlags(remoteConfig))
+	mp := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithRemoteFlags(remoteConfig, mixpanel.DefaultFlagsExposureTracker))
 
 	ctx := context.Background()
 
@@ -155,7 +155,7 @@ func main() {
 		},
 	}
 
-	mp := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithRemoteFlags(remoteConfig))
+	mp := mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithRemoteFlags(remoteConfig, mixpanel.DefaultFlagsExposureTracker))
 
 	ctx := context.Background()
 
@@ -165,5 +165,44 @@ func main() {
 
 	// Given a flag key and the selected variant for that key, manually track an exposure event for a given flag and assigned variant, after exposing the user to the variant
 	mp.RemoteFlags.TrackExposureEvent(ctx, flagKey, selectedVariant, userContext)
+}
+```
+
+## Custom Exposure Tracking
+
+By default, the SDK sends exposure events synchronously via `DefaultFlagsExposureTracker`. You can provide a custom `TrackerBuilder` — a function that receives the `*ApiClient` and returns a `flags.Tracker` — to control how exposure events are sent.
+
+### Asynchronous tracker
+
+For example, to avoid blocking on exposure event delivery, you could wrap the tracking call in a goroutine like shown below. If desired, you could implement controls around how many active go routines can be in flight at once.
+
+```go
+package main
+
+import (
+	"context"
+
+	mixpanel "github.com/mixpanel/mixpanel-go"
+	"github.com/mixpanel/mixpanel-go/flags"
+)
+
+func asyncTracker(client *mixpanel.ApiClient) flags.Tracker {
+	return func(distinctID string, eventName string, props map[string]any) {
+		go func() {
+			event := client.NewEvent(eventName, distinctID, props)
+			_ = client.Track(context.Background(), []*mixpanel.Event{event})
+		}()
+	}
+}
+
+func main() {
+	localConfig := flags.LocalFlagsConfig{
+		FlagsConfig: flags.FlagsConfig{
+			APIHost: "api.mixpanel.com",
+		},
+		EnablePolling:   true,
+		PollingInterval: 60 * time.Second,
+	}
+	mp = mixpanel.NewApiClient("YOUR_PROJECT_TOKEN", mixpanel.WithLocalFlagsAndTracker(localConfig, asyncTracker))
 }
 ```

--- a/pages/docs/tracking-methods/sdks/nodejs/nodejs-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/nodejs/nodejs-flags.mdx
@@ -74,6 +74,16 @@ const userContext = {
 const variantValue = mixpanel.local_flags.getVariantValue(flagKey, fallbackValue, userContext);
 ```
 
+To suppress automatic exposure tracking, pass `false` as the optional 4th parameter, then manually call `trackExposureEvent` when you're ready to expose the user to the variant.
+
+```javascript
+// Pass false to suppress automatic exposure tracking
+const variantValue = mixpanel.local_flags.getVariantValue(flagKey, fallbackValue, userContext, false);
+
+// Manually track exposure when you're ready to expose the user to the variant
+mixpanel.local_flags.trackExposureEvent(flagKey, selectedVariant, userContext);
+```
+
 ## Remote Evaluation
 
 - The SDK is configured with a `remote_flags_config` object to use remote evaluation.
@@ -90,6 +100,16 @@ const mixpanel = Mixpanel.init('YOUR_PROJECT_TOKEN', {
 
 // getVariantValue usage is the same as for local evaluation, but will make a network call to Mixpanel servers at assignment time.
 const variantValue = await mixpanel.remote_flags.getVariantValue(flagKey, fallbackValue, userContext);
+```
+
+To suppress automatic exposure tracking, pass `false` as the optional 4th parameter, then manually call `trackExposureEvent` when you're ready to expose the user to the variant.
+
+```javascript
+// Pass false to suppress automatic exposure tracking
+const variantValue = await mixpanel.remote_flags.getVariantValue(flagKey, fallbackValue, userContext, false);
+
+// Manually track exposure when you're ready to expose the user to the variant
+mixpanel.remote_flags.trackExposureEvent(flagKey, selectedVariant, userContext);
 ```
 
 ## Evaluate all flags at once

--- a/pages/docs/tracking-methods/sdks/nodejs/nodejs-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/nodejs/nodejs-flags.mdx
@@ -74,16 +74,6 @@ const userContext = {
 const variantValue = mixpanel.local_flags.getVariantValue(flagKey, fallbackValue, userContext);
 ```
 
-To suppress automatic exposure tracking, pass `false` as the optional 4th parameter, then manually call `trackExposureEvent` when you're ready to expose the user to the variant.
-
-```javascript
-// Pass false to suppress automatic exposure tracking
-const variantValue = mixpanel.local_flags.getVariantValue(flagKey, fallbackValue, userContext, false);
-
-// Manually track exposure when you're ready to expose the user to the variant
-mixpanel.local_flags.trackExposureEvent(flagKey, selectedVariant, userContext);
-```
-
 ## Remote Evaluation
 
 - The SDK is configured with a `remote_flags_config` object to use remote evaluation.
@@ -102,10 +92,20 @@ const mixpanel = Mixpanel.init('YOUR_PROJECT_TOKEN', {
 const variantValue = await mixpanel.remote_flags.getVariantValue(flagKey, fallbackValue, userContext);
 ```
 
-To suppress automatic exposure tracking, pass `false` as the optional 4th parameter, then manually call `trackExposureEvent` when you're ready to expose the user to the variant.
+## Suppress automatic exposure tracking
+
+To suppress automatic exposure tracking, pass `false` as the optional 4th parameter, then manually call `trackExposureEvent` when you're ready to expose the user to the variant. This applies to both local and remote evaluation.
 
 ```javascript
-// Pass false to suppress automatic exposure tracking
+// Local evaluation - pass false to suppress automatic exposure tracking
+const variantValue = mixpanel.local_flags.getVariantValue(flagKey, fallbackValue, userContext, false);
+
+// Manually track exposure when you're ready to expose the user to the variant
+mixpanel.local_flags.trackExposureEvent(flagKey, selectedVariant, userContext);
+```
+
+```javascript
+// Remote evaluation - pass false to suppress automatic exposure tracking
 const variantValue = await mixpanel.remote_flags.getVariantValue(flagKey, fallbackValue, userContext, false);
 
 // Manually track exposure when you're ready to expose the user to the variant

--- a/pages/docs/tracking-methods/sdks/python/python-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/python/python-flags.mdx
@@ -86,14 +86,26 @@ mp = mixpanel.Mixpanel(PROJECT_TOKEN, remote_flags_config=remote_config)
 variant_value = mp.remote_flags.get_variant_value(flag_key, fallback_variant, user_context)
 ```
 
-### Suppress automatic exposure tracking
+## Suppress automatic exposure tracking
 
-By default, `get_variant_value()` automatically tracks an exposure event. Note that `get_variant_value()` does not expose a `reportExposure` parameter — to suppress automatic exposure tracking, call `get_variant()` directly with `reportExposure=False`, then manually track the exposure when you're ready to expose the user to the variant.
+By default, `get_variant_value()` automatically tracks an exposure event. Note that `get_variant_value()` does not expose a `report_exposure` parameter — to suppress automatic exposure tracking, call `get_variant()` directly with `report_exposure=False`, then manually track the exposure when you're ready to expose the user to the variant. This applies to both local and remote evaluation.
 
 ```python
 from mixpanel import SelectedVariant
 
-# To suppress automatic exposure tracking, use get_variant() directly with reportExposure=False
+# Local evaluation - suppress automatic exposure tracking with report_exposure=False
+fallback = SelectedVariant(variant_value=fallback_variant)
+variant = mp.local_flags.get_variant(flag_key, fallback, user_context, report_exposure=False)
+variant_value = variant.variant_value
+
+# Manually track exposure when you're ready to expose the user to the variant
+mp.local_flags.track_exposure_event(flag_key, variant, user_context)
+```
+
+```python
+from mixpanel import SelectedVariant
+
+# Remote evaluation - suppress automatic exposure tracking with report_exposure=False
 fallback = SelectedVariant(variant_value=fallback_variant)
 variant = mp.remote_flags.get_variant(flag_key, fallback, user_context, reportExposure=False)
 variant_value = variant.variant_value

--- a/pages/docs/tracking-methods/sdks/python/python-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/python/python-flags.mdx
@@ -86,6 +86,22 @@ mp = mixpanel.Mixpanel(PROJECT_TOKEN, remote_flags_config=remote_config)
 variant_value = mp.remote_flags.get_variant_value(flag_key, fallback_variant, user_context)
 ```
 
+### Suppress automatic exposure tracking
+
+By default, `get_variant_value()` automatically tracks an exposure event. Note that `get_variant_value()` does not expose a `reportExposure` parameter — to suppress automatic exposure tracking, call `get_variant()` directly with `reportExposure=False`, then manually track the exposure when you're ready to expose the user to the variant.
+
+```python
+from mixpanel import SelectedVariant
+
+# To suppress automatic exposure tracking, use get_variant() directly with reportExposure=False
+fallback = SelectedVariant(variant_value=fallback_variant)
+variant = mp.remote_flags.get_variant(flag_key, fallback, user_context, reportExposure=False)
+variant_value = variant.variant_value
+
+# Manually track exposure when you're ready to expose the user to the variant
+mp.remote_flags.track_exposure_event(flag_key, variant, user_context)
+```
+
 ### Evaluate all flags at once
 
 Below is a remote evaluation sample of evaluating all flags for a given user context at once.


### PR DESCRIPTION
- adds sample for optional exposure event tracking for node & python. (Added an eng item for syncing this behavior to the other server side sdk's)

- Updates go SDK docs 