### PR TITLE
Add error handling docs for loadFlags() callbacks

### DIFF
--- a/pages/docs/tracking-methods/sdks/flutter/flutter-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/flutter/flutter-flags.mdx
@@ -97,6 +97,18 @@ FeatureFlags flags = mixpanel.getFeatureFlags();
 await flags.loadFlags();
 ```
 
+The `loadFlags()` Future completes successfully when flags have been refreshed, or throws a `PlatformException` on failure (e.g., network error). You can use try/catch to handle errors:
+
+```dart
+try {
+  await flags.loadFlags();
+  // Flags have been successfully refreshed
+} on PlatformException catch (e) {
+  // Flag fetch failed (e.g., network error)
+  print('Failed to load flags: ${e.message}');
+}
+```
+
 <Callout type="info">
 On Web, `loadFlags()` is not supported. Use `updateContext()` to trigger a flag reload instead.
 </Callout>

--- a/pages/docs/tracking-methods/sdks/javascript/javascript-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/javascript/javascript-flags.mdx
@@ -85,6 +85,18 @@ mixpanel.flags.update_context({
 });
 ```
 
+3) To reload flags without changing context, you can call `load_flags` directly. The returned Promise resolves on success or rejects on failure:
+
+```javascript
+try {
+  await mixpanel.flags.load_flags();
+  // Flags have been successfully refreshed
+} catch (error) {
+  // Flag fetch failed (e.g., network error)
+  console.error('Failed to load flags:', error);
+}
+```
+
 ## Flag Evaluation
 
 Lookup the assigned value for a feature flag.


### PR DESCRIPTION
## Summary
- Add try/catch error handling documentation for `loadFlags()` in the Flutter feature flags docs, showing how `PlatformException` is thrown on failure
- Add `load_flags()` usage and error handling documentation in the JavaScript feature flags docs, showing the Promise reject/catch pattern

## Test plan
- [ ] Verify the Flutter code snippet renders correctly on the docs site
- [ ] Verify the JavaScript code snippet renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)