### PR TITLE
[mcp] Adding new tools Duplicate/Delete/Update dashboards

### DIFF
--- a/pages/docs/mcp.mdx
+++ b/pages/docs/mcp.mdx
@@ -26,7 +26,7 @@ A typical workflow looks like:
 | | `Get-Report` | Retrieve a saved report, optionally including results |
 | **Dashboards** | `Create-Dashboard` | Create a new dashboard with text cards and reports |
 | | `List-Dashboards` | Browse dashboards in a project |
-| | `Get-Dashboard` | Retrieve a specific dashboard |
+| | `Get-Dashboard` | Retrieve a dashboard's metadata, text cards, and reports |
 | | `Update-Dashboard` | Modify a dashboard's metadata, rows, and layout |
 | | `Duplicate-Dashboard` | Create a copy of an existing dashboard |
 | | `Delete-Dashboard` | Delete a dashboard |

--- a/pages/docs/mcp.mdx
+++ b/pages/docs/mcp.mdx
@@ -27,6 +27,9 @@ A typical workflow looks like:
 | **Dashboards** | `Create-Dashboard` | Create a new dashboard with text cards and reports |
 | | `List-Dashboards` | Browse dashboards in a project |
 | | `Get-Dashboard` | Retrieve a specific dashboard |
+| | `Update-Dashboard` | Modify a dashboard's metadata, rows, and layout |
+| | `Duplicate-Dashboard` | Create a copy of an existing dashboard |
+| | `Delete-Dashboard` | Delete a dashboard |
 | **Data Discovery** | `Get-Projects` | List your projects and workspaces |
 | | `Get-Events` | Browse all events in a project |
 | | `Get-Property-Names` | Explore properties for events or users |


### PR DESCRIPTION
## Summary

- Added three new MCP dashboard management tools to the Available Tools table: `Update-Dashboard`, `Duplicate-Dashboard`, and `Delete-Dashboard`

## Test plan
- [x] Verify the Available Tools table renders correctly with the new rows
- [x] Confirm the new entries match the existing table styling and alignment