### PR TITLE
[DEV-72] chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/cspell.yaml
+++ b/.github/workflows/cspell.yaml
@@ -9,8 +9,8 @@ jobs:
   spellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: streetsidesoftware/cspell-action@v8
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: streetsidesoftware/cspell-action@9cd41bb518a24fefdafd9880cbab8f0ceba04d28  # v8
         with:
           # Define glob patterns to filter the files to be checked. Use a new line between patterns to define multiple patterns.
           # The default is to check ALL files that were changed in in the pull_request or push.

--- a/.github/workflows/rdme-delete-staging.yml
+++ b/.github/workflows/rdme-delete-staging.yml
@@ -15,8 +15,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v4
-      - uses: actions/setup-node@v5
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: 20
           cache: 'npm'

--- a/.github/workflows/rdme-docs.yml
+++ b/.github/workflows/rdme-docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
       - name: Run `docs` command 🚀
         uses: readmeio/rdme@5d702394cb1fd1dc3fab6e0769b44b56c9d425d1  # rdme version 10.6.0

--- a/.github/workflows/rdme-openapi.yml
+++ b/.github/workflows/rdme-openapi.yml
@@ -12,8 +12,8 @@ jobs:
   rdme-openapi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v5
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
       with:
         node-version: 20.x
     - run: npm ci

--- a/.github/workflows/rdme-staging.yml
+++ b/.github/workflows/rdme-staging.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: 20
           cache: 'npm'
@@ -76,7 +76,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:
           sparse-checkout: |
             .github
@@ -85,7 +85,7 @@ jobs:
       # Build PR Comment
       - name: Build PR comment
         id: build-pr-comment
-        uses: actions/github-script@v8
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           result-encoding: string
           script: |

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     # https://github.com/actions/stale
-    - uses: actions/stale@v10.2.0
+    - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: 180

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,9 +16,9 @@ jobs:
         node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v5
+      uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
       with:
         node-version: ${{ matrix.node-version }}
     - run: npm ci

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -10,7 +10,7 @@ jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information


### PR DESCRIPTION
## Summary
Pin all GitHub Actions workflow steps to immutable full commit SHAs instead of mutable tags or branches.

## Why
Mutable tags can be moved after the fact, making it possible for a supply-chain attack to inject malicious code into CI. Pinning to a commit SHA ensures the exact version of an action is used, and the original tag is preserved as an inline comment for readability.

## Verification
Review the diff — all `uses:` lines with third-party actions should now reference a 40-character commit SHA with the original tag as an inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Linear: https://linear.app/mixpanel/issue/DEV-72/pin-all-github-actions-to-commit-shas