### PR TITLE
[DEV-74] chore: add 30-day dependabot cooldown to all ecosystems

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,16 +1,18 @@
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: chore(deps-gha)
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: chore(deps-npm)
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore(deps-gha)
+  cooldown:
+    default-days: 30
+- package-ecosystem: npm
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+    prefix: chore(deps-npm)
+  cooldown:
+    default-days: 30


### PR DESCRIPTION
Adds `cooldown: default-days: 30` to all dependabot ecosystem entries to reduce PR noise from brand-new releases.

Linear: https://linear.app/mixpanel/issue/DEV-74/ensure-all-repos-have-dependabotyml-with-30-day-cooldown