### PR TITLE
React Native Session Replay SDK - Support for remote configuration 

### DIFF
--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -257,7 +257,7 @@ Three modes are available:
 
 - `Disabled`: Do not use remote configuration and proceed to use the hardcoded initial options provided by the user during initialization. This is the default behavior. 
 - `Fallback`: Attempt to retrieve remote configuration and proceed with those settings. If there is failure or timeout (500 ms), will use previously cached remote settings (from last successful fetch) or the SDK initialization config.
-- `Strict`: Requires successful remote configuration fetch for SDK initialization. If there is failure or timeout (500 ms), SDK initialization will fail and the Session Replay features will be unavailable.
+- `Strict`: Requires successful remote configuration fetch for SDK initialization. If there is failure or timeout (500 ms), SDK initialization will fail and the Session Replay features will be unavailable for that app launch.
 
 Can use this setting to quickly update and adjust configurations to your liking.
 

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -256,7 +256,7 @@ You can set the `remote_settings_mode` for your project in Mixpanel under `Setti
 Three modes are available:
 
 - `Disabled`: Do not use remote configuration and proceed to use the hardcoded initial options provided by the user during initialization. This is the default behavior. 
-- `Fallback`: Attempt to retrieve remote configuration and proceed with those settings. If there is failure or timeout (500 ms), will use previously cached remote settings (from last successful fetch) or the SDK initialization config.
+- `Fallback`: Attempt to retrieve remote configuration and proceed with those settings. If there is failure or timeout (500 ms), we will use the previously cached remote settings (if one exists from the last successful fetch). If no existing remote settings are cached, we will use the values from the SDK initialization config.
 - `Strict`: Requires successful remote configuration fetch for SDK initialization. If there is failure or timeout (500 ms), SDK initialization will fail and the Session Replay features will be unavailable for that app launch.
 
 Can use this setting to quickly update and adjust configurations to your liking.

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -264,7 +264,7 @@ You can use this setting to quickly update and adjust configurations to your lik
 List of currently supported remote settings:
 - `recordingSessionsPercent`
 
-Settings that are not yet supported, will not appear in the remote configuration. These non-included options will use the value that was provided during initialization or the default value if not provided.
+Settings not yet supported by remote configuration will use the value provided during initialization, or the default value if none was provided
 
 ## Privacy & Data Masking
 

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -108,7 +108,7 @@ const config = new MPSessionReplayConfig({
 | `autoMaskedViews`          | MPSessionReplayMask[] | All types | View types to automatically mask                |
 | `flushInterval`            | number                | `10`      | Interval in seconds to flush recordings         |
 | `enableLogging`            | boolean               | `false`   | Enable debug logging                            |
-| `remoteSettingsMode`       | MPSessionReplayRemoteSettingsMode | `Disabled`   | Setting for handling remote configuration during SDK initialization. Can be `Disabled`, `Fallback`, `Strict`.                    |
+| `remoteSettingsMode`       | MPSessionReplayRemoteSettingsMode | `Disabled`   | Setting for handling remote configuration during SDK initialization. Can be `Disabled`/ `Fallback`/ `Strict`.                    |
 
 ### Auto-Masked View Types
 

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -248,7 +248,7 @@ await MPSessionReplay.identify("authenticated-user-456");
 ## Remote Configuration
 
 <Callout type="info">
-  Available in React Native SDK version `1.1.0` and later. Requires a paid Session Replay add-on. 
+  Available in React Native Session Replay SDK version `1.1.0` and later. Requires a paid Session Replay add-on. 
 </Callout>
 
 You can set the `remote_settings_mode` for your project in Mixpanel under `Settings > Organization Settings > Session Replay`. Using this, you can quickly set SDK options remotely without needing to update your app. This allows you to adjust recording settings, such as sampling rates, on the fly based on your needs.

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -259,7 +259,7 @@ Three modes are available:
 - `Fallback`: Attempt to retrieve remote configuration and proceed with those settings. If there is failure or timeout (500 ms), we will use the previously cached remote settings (if one exists from the last successful fetch). If no existing remote settings are cached, we will use the values from the SDK initialization config.
 - `Strict`: Requires successful remote configuration fetch for SDK initialization. If there is failure or timeout (500 ms), SDK initialization will fail and the Session Replay features will be unavailable for that app launch.
 
-Can use this setting to quickly update and adjust configurations to your liking.
+You can use this setting to quickly update and adjust configurations to your liking.
 
 List of currently supported remote settings:
 - `recordingSessionsPercent`

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -1,3 +1,5 @@
+import { Callout } from 'nextra/components'
+
 # Implement Session Replay (React Native)
 
 Mixpanel's React Native Session Replay SDK enables you to capture and analyze user interactions in your mobile applications. Built as a Turbo Module for React Native's New Architecture, it provides native implementations for both iOS and Android with a unified JavaScript API.
@@ -106,6 +108,7 @@ const config = new MPSessionReplayConfig({
 | `autoMaskedViews`          | MPSessionReplayMask[] | All types | View types to automatically mask                |
 | `flushInterval`            | number                | `10`      | Interval in seconds to flush recordings         |
 | `enableLogging`            | boolean               | `false`   | Enable debug logging                            |
+| `remoteSettingsMode`       | MPSessionReplayRemoteSettingsMode | Disabled   | Setting for handling remote configuration during SDK initialization. Can be Disabled, Fallback, Strict.                    |
 
 ### Auto-Masked View Types
 
@@ -241,6 +244,27 @@ identify(distinctId: string): Promise<void>
 // Update user ID after authentication
 await MPSessionReplay.identify("authenticated-user-456");
 ```
+
+## Remote Configuration
+
+<Callout type="info">
+  Available in React Native SDK version `1.1.0` and later. Requires a paid Session Replay add-on. 
+</Callout>
+
+You can set the `remote_settings_mode` for your project in Mixpanel under `Settings > Organization Settings > Session Replay`. Using this, you can quickly set SDK options remotely without needing to update your app. This allows you to adjust recording settings, such as sampling rates, on the fly based on your needs.
+
+Three modes are available:
+
+- `Disabled`: Do not use remote configuration and proceed to use the hardcoded initial options provided by the user during initialization. This is the default behavior. 
+- `Fallback`: Attempt to retrieve remote configuration and proceed with those settings. If there is failure or timeout (500 ms), will use previously cached remote settings (from last successful fetch) or the SDK initialization config.
+- `Strict`: Requires successful remote configuration fetch for SDK initialization. If there is failure or timeout (500 ms), SDK initialization will fail and the Session Replay features will be unavailable.
+
+Can use this setting to quickly update and adjust configurations to your liking.
+
+List of currently supported remote settings:
+- `recordingSessionsPercent`
+
+Settings that are not yet supported, will not appear in the remote configuration. These non-included options will use the value that was provided during initialization or the default value if not provided.
 
 ## Privacy & Data Masking
 

--- a/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
+++ b/pages/docs/tracking-methods/sdks/react-native/react-native-replay.mdx
@@ -108,7 +108,7 @@ const config = new MPSessionReplayConfig({
 | `autoMaskedViews`          | MPSessionReplayMask[] | All types | View types to automatically mask                |
 | `flushInterval`            | number                | `10`      | Interval in seconds to flush recordings         |
 | `enableLogging`            | boolean               | `false`   | Enable debug logging                            |
-| `remoteSettingsMode`       | MPSessionReplayRemoteSettingsMode | Disabled   | Setting for handling remote configuration during SDK initialization. Can be Disabled, Fallback, Strict.                    |
+| `remoteSettingsMode`       | MPSessionReplayRemoteSettingsMode | `Disabled`   | Setting for handling remote configuration during SDK initialization. Can be `Disabled`, `Fallback`, `Strict`.                    |
 
 ### Auto-Masked View Types
 


### PR DESCRIPTION
This pull request updates the React Native Session Replay SDK documentation to include details about the new remote configuration feature. It introduces a new configuration option, explains its usage, and describes the available modes and supported remote settings.

Documentation updates for remote configuration:

* Added a new configuration option, `remoteSettingsMode`, to the `MPSessionReplayConfig` options table, allowing users to control how remote configuration is handled during SDK initialization.
* Introduced a new "Remote Configuration" section explaining the feature, its requirements (SDK version 1.1.0+ and paid add-on), and how to use it, including descriptions of the three available modes: Disabled, Fallback, and Strict.
* Listed the currently supported remote setting (`recordingSessionsPercent`) and clarified how unsupported settings are handled.
* Added a callout to highlight version and plan requirements for the remote configuration feature.
* Imported the `Callout` component to support the new informational callout in the documentation.