### PR TITLE
Adding React Native Session Replay SDK to the table of all SDKs

### DIFF
--- a/pages/docs/tracking-methods/sdks.mdx
+++ b/pages/docs/tracking-methods/sdks.mdx
@@ -34,6 +34,7 @@ If you do not see an SDK in your preferred language, leverage our [HTTP APIs](ht
 <Cards>
   <Cards.Card icon title="Session Replay (Android)" href="/docs/tracking-methods/sdks/android/android-replay" />
   <Cards.Card icon title="Session Replay (Swift)" href="/docs/tracking-methods/sdks/swift/swift-replay" />
+  <Cards.Card icon title="Session Replay (React Native)" href="/docs/tracking-methods/sdks/react-native/react-native-replay" />
 </Cards>
 
 


### PR DESCRIPTION
Adding React Native Session Replay SDK to the table of all SDKs