### PR TITLE
Pin GHA SHA

### DIFF
--- a/.github/actions/create-or-update-comment/action.yaml
+++ b/.github/actions/create-or-update-comment/action.yaml
@@ -15,7 +15,7 @@ runs:
   using: 'composite'
   steps:
     - name: Create or update comment
-      uses: actions/github-script@v6
+      uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
       env:
         ISSUE_NUMBER: ${{ inputs.issue-number }}
         KEY: ${{ inputs.key }}


### PR DESCRIPTION
Error: The action actions/github-script@v6 is not allowed in mixpanel/docs because all actions must be pinned to a full-length commit SHA.