### PR TITLE
Bump checkout v4 to v6

### DIFF
--- a/.github/workflows/rdme-delete-staging.yml
+++ b/.github/workflows/rdme-delete-staging.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
           node-version: 20

--- a/.github/workflows/rdme-docs.yml
+++ b/.github/workflows/rdme-docs.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
 
       - name: Run `docs` command 🚀
         uses: readmeio/rdme@5d702394cb1fd1dc3fab6e0769b44b56c9d425d1  # rdme version 10.6.0

--- a/.github/workflows/rdme-openapi.yml
+++ b/.github/workflows/rdme-openapi.yml
@@ -12,7 +12,7 @@ jobs:
   rdme-openapi:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
     - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
       with:
         node-version: 20.x

--- a/.github/workflows/rdme-staging.yml
+++ b/.github/workflows/rdme-staging.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo 📚
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
 
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
         with:
@@ -76,7 +76,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
         with:
           sparse-checkout: |
             .github

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
         node-version: [20.x]
 
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+    - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
     - name: Use Node.js ${{ matrix.node-version }}
       uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444  # v5
       with:

--- a/.github/workflows/vercel-preview.yaml
+++ b/.github/workflows/vercel-preview.yaml
@@ -10,7 +10,7 @@ jobs:
   Deploy-Preview:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information


### PR DESCRIPTION
getting some errors with v4, maybe the answer is bumping to v6. example error: https://github.com/mixpanel/docs/actions/runs/23921982725/job/69770237298?pr=2498