### PR TITLE
Update deprecation notice for TLS protocols and CNSA version

### DIFF
--- a/pages/changelogs/2026-02-26-tls1011-deprecation.mdx
+++ b/pages/changelogs/2026-02-26-tls1011-deprecation.mdx
@@ -6,7 +6,7 @@ createdAt: "2026-02-26T10:00:00.000Z"
 updatedAt: "2026-02-26T10:00:00.000Z"
 date: "2026-02-26"
 thumbnail: ""
-description: "Starting April 2026, we will be deprecating support for legacy TLS 1.0 and 1.1 protocols and adopting CNSA 2.0 cryptographic algorithms across our APIs and web app. "
+description: "Starting April 2026, we will be deprecating support for legacy TLS 1.0 and 1.1 protocols and adopting CNSA 1.0 cryptographic algorithms across our APIs and web app. "
 isAnnouncement: false
 ---
 
@@ -18,7 +18,7 @@ isAnnouncement: false
 
 To ensure we provide the most robust protection against evolving threats, we are upgrading our network security configuration. 
 
-**Starting April 2026, we will be deprecating support for legacy TLS 1.0 and 1.1 protocols and adopting CNSA 2.0 cryptographic algorithms across our APIs and web app.**
+**Starting April 2026, we will be deprecating support for legacy TLS 1.0 and 1.1 protocols and adopting CNSA 1.0 cryptographic algorithms across our APIs and web app.**
 
 After this date, all API requests must use at least TLS 1.2. 
 Using at least TLS 1.2 is a recommended security best practice to improve data integrity and maintain compliance with industry standards.


### PR DESCRIPTION
Erroneous suggestec copy w/ 2.0 reference. This is a future standard that protects against quantum attacks. We are a couple years out from that still.