### PR TITLE
Clarify warehouse connector billing for legacy event timestamp accounts

### DIFF
--- a/pages/docs/tracking-methods/warehouse-connectors.mdx
+++ b/pages/docs/tracking-methods/warehouse-connectors.mdx
@@ -919,7 +919,9 @@ Billing varies by operation type and connector mode. The tables below explain ho
 |                                           | Append        | ❌            | ❌          |
 |                                           | Mirror        | ✅            | ✅          |
 
-The above table applies if your account uses ingestion time billing. If your account is on legacy event timestamp billing, only events sent in with timestamps in the current month will be included in billing. More details on ingestion time vs. event timestamp billing can be found in [this section](/docs/pricing#are-monthly-events-calculated-based-on-ingestion-time-or-event-timestamp).
+The above table applies if your account uses ingestion time billing. If your account is on legacy event timestamp billing:
+- **Event inserts** are billed only if the event timestamp is in the current billing month. Events with timestamps in previous months are not billed.
+- **Updates and deletes** are always billed at ingestion time, regardless of the event timestamp on the original event. More details on ingestion time vs. event timestamp billing can be found in [this section](/docs/pricing#are-monthly-events-calculated-based-on-ingestion-time-or-event-timestamp).
 
 If you’re planning on backfilling a significant amount of historical events and need help understanding how it will impact your costs, please reach out to your Mixpanel account manager or [contact support](https://mixpanel.com/get-support).
 


### PR DESCRIPTION
Updates and deletes are billed at ingestion time for all accounts, including those on legacy event timestamp billing. The previous wording implied that all operations follow event timestamp billing for legacy accounts, which was misleading.