### PR TITLE
Revise forecasting tool description in alerts documentation

### DIFF
--- a/pages/docs/features/alerts.mdx
+++ b/pages/docs/features/alerts.mdx
@@ -343,7 +343,7 @@ Anomaly Detection alerts automatically monitor your metrics and notify you when 
 
 **Forecasting tool**
 
-Anomaly Detection uses [Prophet](https://facebook.github.io/prophet/), an open-source forecasting tool designed for time series data. Prophet handles missing data points, trend shifts, and large outliers effectively.
+Anomaly Detection uses an LLM forecasting tool designed for time series data. This handles missing data points, trend shifts, and large outliers effectively.
 
 **Confidence interval**
 


### PR DESCRIPTION
Updated description of the forecasting tool used in Anomaly Detection as we no longer use Prophet. Per Remy, it does not seem necessary to disclose TimesFM