### PR TITLE
Update experiments docs: rename "Retro-AA" to "Pre-Experiment Bias"

### DIFF
--- a/pages/docs/experiments.mdx
+++ b/pages/docs/experiments.mdx
@@ -242,10 +242,6 @@ You can also add the experiment breakdowns and filters directly in a report via 
 
 ## Advanced Statistical Methods
 
-<Callout type="info">
-  Advanced statistical methods are currently in beta.
-</Callout>
-
 Mixpanel offers several advanced statistical options to help you get more reliable experiment results. These features address common challenges in experimentation: controlling for multiple comparisons, handling outliers, validating experiment setup, and reducing variance to reach significance faster.
 
 ### Methods at a Glance
@@ -255,7 +251,7 @@ Mixpanel offers several advanced statistical options to help you get more reliab
 | **Bonferroni Correction** | Makes significance thresholds stricter to account for testing multiple metrics/variants at once | You're tracking multiple metrics or testing multiple variants | If a metric loses significance after correction, don't treat it as a confirmed winner. Run a follow-up experiment focused on that metric alone. |
 | **Winsorization** | Caps extreme outlier values at a percentile you choose | Revenue or value-based metrics where outliers are common | If results change substantially after Winsorization, this indicates your original results were driven by outliers. Decide whether your business decision is about typical users or extreme ones. |
 | **SRM** | Checks whether your variant split matches the configured allocation | Always on as a health check | Pause the experiment. Identify and fix the root cause of the mismatch, then restart the experiment. |
-| **Retro-AA** | Checks whether variant groups were already different *before* the experiment started | Always on as a health check | Your groups had pre-existing bias. Consider enabling CUPED to correct for it. Investigate your assignment logic to prevent it in future experiments. |
+| **Pre-Experiment Bias** | Checks whether variant groups were already different *before* the experiment started | Always on as a health check | Your groups had pre-existing bias. Consider enabling CUPED to correct for it. Investigate your assignment logic to prevent it in future experiments. |
 | **CUPED** | Uses pre-experiment behavior to adjust for natural variance and pre-existing bias, helping you reach significance faster | Your users have pre-experiment history and your metrics have high natural variance | If confidence intervals don't noticeably tighten, pre-experiment behavior isn't predictive for your metrics. Results are still valid, you just won't get faster detection. |
 
 ### Bonferroni Correction
@@ -300,17 +296,17 @@ Small imbalances can happen by random chance, but larger mismatches often indica
 
 If Mixpanel detects a statistically significant sample ratio mismatch, you'll see a warning. We recommend investigating the root cause of the mismatch and restarting the experiment after fixing it.
 
-#### Retrospective-AA Analysis (Retro-AA)
+#### Pre-Experiment Bias Analysis
 
-When you see lift in your experiment, you want to be confident it's caused by your treatment—not by pre-existing differences between the groups. Retro-AA helps you check this.
+When you see lift in your experiment, you want to be confident it's caused by your treatment—not by pre-existing differences between the groups. Pre-Experiment Bias helps you check this.
 
 The idea is simple: Mixpanel runs the same statistical analysis on 2 weeks of pre-experiment data. It looks at how each variant's users behaved *before* they were exposed to the experiment, using the same metrics you're measuring during the experiment.
 
-If the groups were properly randomized, there should be no significant difference in the pre-experiment period—users hadn't been treated yet, so nothing should cause a difference. But if Retro-AA finds statistically significant lift in the pre-experiment data, that's a red flag. It suggests the groups weren't equivalent to begin with, which means any lift you see during the experiment might not be caused by your treatment.
+If the groups were properly randomized, there should be no significant difference in the pre-experiment period—users hadn't been treated yet, so nothing should cause a difference. But if Pre-Experiment Bias finds statistically significant lift in the pre-experiment data, that's a red flag. It suggests the groups weren't equivalent to begin with, which means any lift you see during the experiment might not be caused by your treatment.
 
-**Example:** Your experiment shows the treatment group has 15% higher engagement. But Retro-AA reveals this same group already had 12% higher engagement before the experiment started. This suggests your randomization may have assigned more naturally-engaged users to treatment, and the lift you're seeing is largely a pre-existing difference rather than a treatment effect.
+**Example:** Your experiment shows the treatment group has 15% higher engagement. But Pre-Experiment Bias reveals this same group already had 12% higher engagement before the experiment started. This suggests your randomization may have assigned more naturally-engaged users to treatment, and the lift you're seeing is largely a pre-existing difference rather than a treatment effect.
 
-Retro-AA failing for a metric doesn't necessarily invalidate your experiment. Enabling CUPED may help reduce the impact of pre-experiment bias on the data, allowing you to still analyze the results. You may however want to review your implementation to ensure assignment is not biased towards some users.
+Pre-Experiment Bias failing for a metric doesn't necessarily invalidate your experiment. Enabling CUPED may help reduce the impact of pre-experiment bias on the data, allowing you to still analyze the results. You may however want to review your implementation to ensure assignment is not biased towards some users.
 
 #### Common reasons health checks may fail:
 


### PR DESCRIPTION
## Summary
- Updated terminology in experiments documentation to match product naming
- Changed all references from "Retro-AA" and "Retrospective-AA Analysis" to "Pre-Experiment Bias"
- Removed beta label from Advanced Statistical Methods section as health checks are no longer in beta

## Changes
- Line 246: Removed "Advanced statistical methods are currently in beta" callout
- Line 258: Updated table entry from "Retro-AA" to "Pre-Experiment Bias"
- Line 303: Changed section heading from "Retrospective-AA Analysis (Retro-AA)" to "Pre-Experiment Bias Analysis"
- Lines 305-313: Replaced all occurrences of "Retro-AA" with "Pre-Experiment Bias" in descriptive text

## Test plan
- [x] Verified all occurrences of "Retro-AA" have been replaced
- [x] Confirmed no other files in the docs contain "Retro-AA" terminology
- [x] Removed beta callout for advanced statistical methods
- [x] Content reads naturally with the new terminology

🤖 Generated with [Claude Code](https://claude.com/claude-code)