### PR TITLE
clarify that group identifier metrics use group-level exposures

### DIFF
--- a/pages/docs/experiments.mdx
+++ b/pages/docs/experiments.mdx
@@ -221,6 +221,10 @@ Lift, mean, and variance are calculated differently based on the type of metric 
 **Why This Matters:**
 Normalizing by exposed users (not just converters) helps you understand the impact on your entire user base. A feature that increases average order value among buyers but reduces conversion rate may decrease overall revenue per user.
 
+<Callout type="info">
+**Metrics with a Group Identifier:** When you [change a metric's group identifier](/docs/data-structure/advanced/group-analytics#change-the-group-identifier-in-a-report) from Users to a group key (e.g., Company), exposures for that metric are counted at the group level. The number of exposed groups is then used for all of that metric's calculations — normalizing group rates, computing variance, and determining statistical significance. For example, if a metric is set to aggregate by Company and 200 companies have been exposed to the treatment, the group rate is calculated as the total metric value divided by those 200 exposed companies, not by the number of individual users.
+</Callout>
+
 **Custom Formula Metrics:**
 For complex metrics using formulas like `Revenue per User = Total Revenue ÷ Unique Users`, Mixpanel uses propagation of uncertainty to estimate variance. This combines the variances of the component metrics (Total Revenue and Unique Users) to calculate the overall metric's statistical significance. The system assumes metrics in formulas are uncorrelated for these calculations.
 


### PR DESCRIPTION
## Summary
- Add a callout to the experiments docs clarifying that when a metric's group identifier is set to a group key (e.g., Company), exposures for that metric are counted at the group level, and those group-level exposures are used for normalization, variance, and significance calculations.

## Test plan
- [ ] Verify the callout renders correctly on the docs site
- [ ] Verify the link to the Group Analytics docs resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)