### PR TITLE
Add flag persistence public docs

### DIFF
--- a/pages/docs/featureflags.mdx
+++ b/pages/docs/featureflags.mdx
@@ -242,6 +242,34 @@ Remote evaluation makes a network call to Mixpanel servers each time you evaluat
 
 This is ideal for applications requiring cohort-based targeting or sticky variant assignments
 
+### Flag Persistence
+
+<Callout type="info">
+Flag persistence is a client SDK feature. It is officially supported on the Android, Swift, and Flutter (mobile) client SDKs. Support for JavaScript (Web) and React Native is coming soon.
+</Callout>
+
+By default, client SDKs fetch flag assignments from Mixpanel feature flag evaluation endpoint. If the call fails due to network issues, the SDK returns the fallback variant, which can result in an undesirable user experience.
+
+Flag persistence lets the SDK persist assignments to the device so that they are made available, even if the network is not. This is useful for reducing latency at startup and for providing graceful degradation when the network is unavailable.
+
+Persistence is configured with a `variantLookupPolicy`, which accepts one of three strategies:
+
+| Policy | Behavior |
+|--------|----------|
+| `networkOnly` *(default)* | No persistence of variants.Every lookup waits for a fresh network response.|
+| `networkFirst` | The SDK waits for a network response first. If the network fails, previously persisted variants are served as a fallback |
+| `persistenceUntilNetworkSuccess` | Persisted variants are served immediately on launch. The next time a network call succeeds, the variants will update the in-memory state as well as be persisted to the device. |
+
+**TTL:** Both persistent policies accept a configurable TTL (default: 24 hours). Persisted variants older than the TTL are treated as expiring and not served.
+
+**Identity scoping:** Persisted variants are tied to the current `distinct_id`. Calling `identify()` with a different ID or calling `reset()` clears persisted data and triggers a fresh network fetch.
+
+**Variant source:** Each returned variant carries a `source` indicating where the value came from: `network`, `persistence`, or `fallback`. This lets you know at call time whether you are looking at a fresh or persisted assignment.
+
+**`$experiment_started` properties:** When a variant is served, the `$experiment_started` event includes a new `$variant_source` property (`"network"` or `"persistence"`). For persistence-sourced variants, two additional properties are included: `$persisted_at_in_ms` (the epoch ms when the variant set was persisted) and `$ttl_in_ms` (the configured TTL). Fallback variants do not trigger `$experiment_started`.
+
+See the SDK-specific guides below for implementation examples.
+
 ### Local Evaluation
 
 Local evaluation minimizes latency by evaluating flags within your application. This mode is recommended for server-side SDKs used in latency-sensitive server-side applications.

--- a/pages/docs/featureflags.mdx
+++ b/pages/docs/featureflags.mdx
@@ -256,7 +256,7 @@ Persistence is configured with a `variantLookupPolicy`, which accepts one of thr
 
 | Policy | Behavior |
 |--------|----------|
-| `networkOnly` *(default)* | No persistence of variants.Every lookup waits for a fresh network response.|
+| `networkOnly` *(default)* | No persistence of variants. Every lookup waits for a fresh network response.|
 | `networkFirst` | The SDK waits for a network response first. If the network fails, previously persisted variants are served as a fallback |
 | `persistenceUntilNetworkSuccess` | Persisted variants are served immediately on launch. The next time a network call succeeds, the variants will update the in-memory state as well as be persisted to the device. |
 

--- a/pages/docs/tracking-methods/sdks/android/android-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/android/android-flags.mdx
@@ -82,7 +82,7 @@ MixpanelAPI mixpanel = MixpanelAPI.getInstance(getApplicationContext(), "YOUR_PR
 
 Minimum supported SDK version: [`v8.7.0`](https://github.com/mixpanel/mixpanel-android/releases/tag/v8.7.0)
 
-By default (`networkOnly`), the SDK fetches fresh flag assignments on app launch and waits for the network response before variant calls complete. You can enable persistence to persist assignments to SharedPreferences so they are available immediately on subsequent launches.
+By default (`networkOnly`), the SDK fetches fresh flag assignments and waits for the network response before variant calls complete. You can enable persistence to persist assignments to SharedPreferences so they are available immediately on subsequent launches.
 
 Configure a `variantLookupPolicy` on the `FeatureFlagOptions` builder:
 

--- a/pages/docs/tracking-methods/sdks/android/android-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/android/android-flags.mdx
@@ -78,6 +78,86 @@ MixpanelOptions options = new MixpanelOptions.Builder()
 MixpanelAPI mixpanel = MixpanelAPI.getInstance(getApplicationContext(), "YOUR_PROJECT_TOKEN", false, options);
 ```
 
+## Flag Persistence
+
+Minimum supported SDK version: [`v8.7.0`](https://github.com/mixpanel/mixpanel-android/releases/tag/v8.7.0)
+
+By default (`networkOnly`), the SDK fetches fresh flag assignments on app launch and waits for the network response before variant calls complete. You can enable persistence to persist assignments to SharedPreferences so they are available immediately on subsequent launches.
+
+Configure a `variantLookupPolicy` on the `FeatureFlagOptions` builder:
+
+**`networkFirst`** — The SDK waits for the network on every launch. If the network call fails, the persisted value is returned as a fallback. Async getter calls block until the fetch completes (or the fallback is resolved).
+
+```java Java
+FeatureFlagOptions featureFlagOptions = new FeatureFlagOptions.Builder()
+    .enabled(true)
+    .variantLookupPolicy(VariantLookupPolicy.networkFirst())
+    .build();
+
+// getVariantValue waits for the network. Falls back to persisted value if network fails.
+mixpanel.flags.getVariantValue("my-feature-flag", "control", new FlagCompletionCallback<Object>() {
+    @Override
+    public void onComplete(Object value) {
+        // value is from the network response, or from persistence if the network was unavailable
+    }
+});
+```
+
+**`persistenceUntilNetworkSuccess`** — Persisted variants are returned immediately on launch. Each getter call while serving persisted data triggers a background network fetch (deduplicated — only one fetch runs at a time). If the fetch fails, persisted data continues to be served and the next getter call retries the fetch. Once a fetch succeeds, the in-memory state updates and subsequent calls no longer trigger background fetches.
+
+```java Java
+FeatureFlagOptions featureFlagOptions = new FeatureFlagOptions.Builder()
+    .enabled(true)
+    .variantLookupPolicy(VariantLookupPolicy.persistenceUntilNetworkSuccess())
+    .build();
+
+// getVariantValue returns immediately from persistence. Each call triggers a background fetch
+// until a network response succeeds and replaces the persisted state.
+mixpanel.flags.getVariantValue("my-feature-flag", "control", new FlagCompletionCallback<Object>() {
+    @Override
+    public void onComplete(Object value) {
+        // value is from persistence; background fetch retries on each call until network succeeds
+    }
+});
+```
+
+To customize the TTL (default: 24 hours), pass the value in milliseconds:
+
+```java Java
+long ttlMs = 12 * 60 * 60 * 1000L; // 12 hours
+FeatureFlagOptions featureFlagOptions = new FeatureFlagOptions.Builder()
+    .enabled(true)
+    .variantLookupPolicy(VariantLookupPolicy.networkFirst(ttlMs))
+    .build();
+```
+
+### Variant source
+
+Every `MixpanelFlagVariant` carries a `source` field indicating where the value came from: `Source.Network`, `Source.Persistence`, or `Source.Fallback`. Use `getVariant()` to receive the full variant object.
+
+```java Java
+MixpanelFlagVariant fallback = new MixpanelFlagVariant("control", "control");
+mixpanel.flags.getVariant("my-feature-flag", fallback, new FlagCompletionCallback<MixpanelFlagVariant>() {
+    @Override
+    public void onComplete(MixpanelFlagVariant variant) {
+        Object value = variant.value;
+        MixpanelFlagVariant.Source source = variant.source; // Network, Persistence, or Fallback
+    }
+});
+```
+
+### `$experiment_started` properties
+
+When a variant is served, the `$experiment_started` exposure event includes:
+
+- `$variant_source` — `"network"` or `"persistence"`
+- `$persisted_at_in_ms` — epoch ms when the variant set was persisted *(persistence only)*
+- `$ttl_in_ms` — the configured TTL in ms *(persistence only)*
+
+<Callout type="info">
+Persisted variants are tied to the current `distinct_id`. Calling `identify()` with a new ID or calling `reset()` clears persisted data and triggers a fresh fetch.
+</Callout>
+
 ## Flag Reload
 
 Following initialization, you can reload feature flag assignments in a couple of ways:
@@ -114,6 +194,14 @@ mixpanel.flags.setContext(newContext, new FlagCompletionCallback<Boolean>() {
     }
 });
 ```
+
+4) Calling `reset()` clears all feature flag assignments from memory and triggers a new fetch for the updated `distinct_id`. Requires SDK version [`v8.7.0`](https://github.com/mixpanel/mixpanel-android/releases/tag/v8.7.0) or later.
+
+```java
+mixpanel.reset();
+// Flags are cleared immediately. A new fetch begins for the anonymous distinct_id.
+```
+
 ## Deferred Flag Loading
 
 By default, feature flags are automatically fetched when the app first enters the foreground (`prefetchFlags` defaults to `true`). If your workflow requires calling `identify()` before the first flag fetch — for example, to ensure flags are evaluated against the correct user — you can defer automatic loading by setting `prefetchFlags(false)`:

--- a/pages/docs/tracking-methods/sdks/flutter/flutter-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/flutter/flutter-flags.mdx
@@ -72,6 +72,94 @@ Mixpanel mixpanel = await Mixpanel.init(
 );
 ```
 
+## Flag Persistence
+
+Minimum supported SDK version: [`v2.8.0`](https://github.com/mixpanel/mixpanel-flutter/releases/tag/v2.8.0)
+
+<Callout type="info">
+Flag persistence is supported on iOS and Android. Web support is coming soon. On Web, the `variantLookupPolicy` is treated as `networkOnly` regardless of what is configured.
+</Callout>
+
+By default (`networkOnly`), the SDK fetches fresh flag assignments on each launch and waits for the network response before variant calls complete. You can enable persistence so that assignments are persisted on-device and available immediately on subsequent launches (iOS and Android only).
+
+Configure a `variantLookupPolicy` on `FeatureFlagsConfig`:
+
+**`networkFirst`** — The SDK waits for the network on every launch. If the network call fails, the persisted value is returned as a fallback. Async getter calls block until the fetch completes (or the fallback is resolved).
+
+```dart
+Mixpanel mixpanel = await Mixpanel.init(
+  "YOUR_PROJECT_TOKEN",
+  trackAutomaticEvents: false,
+  featureFlags: FeatureFlagsConfig(
+    enabled: true,
+    variantLookupPolicy: VariantLookupPolicy.networkFirst(),
+  ),
+);
+
+// getVariantValue waits for the network. Falls back to persisted value if network fails.
+FeatureFlags flags = mixpanel.getFeatureFlags();
+dynamic value = await flags.getVariantValue("my-feature-flag", "control");
+// value is from the network response, or from persistence if the network was unavailable
+```
+
+**`persistenceUntilNetworkSuccess`** — Persisted variants are returned immediately on launch. On iOS and Android, each getter call while serving persisted data triggers a background network fetch (deduplicated — only one fetch runs at a time). If the fetch fails, persisted data continues to be served and the next getter call retries the fetch. Once a fetch succeeds, the in-memory state updates and subsequent calls no longer trigger background fetches.
+
+```dart
+Mixpanel mixpanel = await Mixpanel.init(
+  "YOUR_PROJECT_TOKEN",
+  trackAutomaticEvents: false,
+  featureFlags: FeatureFlagsConfig(
+    enabled: true,
+    variantLookupPolicy: VariantLookupPolicy.persistenceUntilNetworkSuccess(),
+  ),
+);
+
+// getVariantValue returns immediately from persistence. Each call (iOS/Android) triggers a
+// background fetch until a network response succeeds and replaces the persisted state.
+FeatureFlags flags = mixpanel.getFeatureFlags();
+dynamic value = await flags.getVariantValue("my-feature-flag", "control");
+// value is from persistence; background fetch retries on each call until network succeeds
+```
+
+To customize the TTL (default: 24 hours), pass a `Duration`:
+
+```dart
+Mixpanel mixpanel = await Mixpanel.init(
+  "YOUR_PROJECT_TOKEN",
+  trackAutomaticEvents: false,
+  featureFlags: FeatureFlagsConfig(
+    enabled: true,
+    variantLookupPolicy: VariantLookupPolicy.networkFirst(
+      persistenceTtl: Duration(hours: 12),
+    ),
+  ),
+);
+```
+
+### Variant source
+
+Every `MixpanelFlagVariant` carries a `source` field indicating where the value came from: `NetworkSource`, `PersistenceSource` (with a `persistedAt` timestamp), or `FallbackSource`. Use `getVariant()` to receive the full variant object.
+
+```dart
+FeatureFlags flags = mixpanel.getFeatureFlags();
+final fallback = MixpanelFlagVariant(key: "control", value: "control");
+MixpanelFlagVariant variant = await flags.getVariant("my-feature-flag", fallback);
+final value = variant.value;
+final source = variant.source; // NetworkSource, PersistenceSource, or FallbackSource
+```
+
+### `$experiment_started` properties
+
+When a variant is served, the `$experiment_started` exposure event includes:
+
+- `$variant_source` — `"network"` or `"persistence"`
+- `$persisted_at_in_ms` — epoch ms when the variant set was persisted *(persistence only)*
+- `$ttl_in_ms` — the configured TTL in ms *(persistence only)*
+
+<Callout type="info">
+Persisted variants are tied to the current `distinct_id`. Calling `identify()` with a new ID or calling `reset()` clears persisted data and triggers a fresh fetch.
+</Callout>
+
 ## Flag Reload
 
 Following initialization, you can reload feature flag assignments. The available methods vary by platform.
@@ -120,6 +208,15 @@ await flags.updateContext({
 <Callout type="info">
 `updateContext` completely replaces the previously set custom context — it does not merge with existing values. The returned `Future` completes when the flag re-fetch is complete.
 </Callout>
+
+### Reset
+
+Calling `reset()` clears all feature flag assignments from memory and triggers a new fetch for the updated `distinct_id`. Requires SDK version [`v2.8.0`](https://github.com/mixpanel/mixpanel-flutter/releases/tag/v2.8.0) or later.
+
+```dart
+mixpanel.reset();
+// Flags are cleared immediately. A new fetch begins for the anonymous distinct_id.
+```
 
 ### Check Flags Ready
 

--- a/pages/docs/tracking-methods/sdks/flutter/flutter-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/flutter/flutter-flags.mdx
@@ -80,7 +80,7 @@ Minimum supported SDK version: [`v2.8.0`](https://github.com/mixpanel/mixpanel-f
 Flag persistence is supported on iOS and Android. Web support is coming soon. On Web, the `variantLookupPolicy` is treated as `networkOnly` regardless of what is configured.
 </Callout>
 
-By default (`networkOnly`), the SDK fetches fresh flag assignments on each launch and waits for the network response before variant calls complete. You can enable persistence so that assignments are persisted on-device and available immediately on subsequent launches (iOS and Android only).
+By default (`networkOnly`), the SDK fetches fresh flag assignments and waits for the network response before variant calls complete. You can enable persistence so that assignments are persisted on-device and available immediately on subsequent launches (iOS and Android only).
 
 Configure a `variantLookupPolicy` on `FeatureFlagsConfig`:
 
@@ -102,7 +102,7 @@ dynamic value = await flags.getVariantValue("my-feature-flag", "control");
 // value is from the network response, or from persistence if the network was unavailable
 ```
 
-**`persistenceUntilNetworkSuccess`** — Persisted variants are returned immediately on launch. On iOS and Android, each getter call while serving persisted data triggers a background network fetch (deduplicated — only one fetch runs at a time). If the fetch fails, persisted data continues to be served and the next getter call retries the fetch. Once a fetch succeeds, the in-memory state updates and subsequent calls no longer trigger background fetches.
+**`persistenceUntilNetworkSuccess`** — Persisted variants are returned immediately on launch. On iOS and Android, each getter call while serving persisted data triggers a background network fetch. If the fetch fails, persisted data continues to be served and the next getter call retries the fetch. Once a fetch succeeds, the in-memory state updates and subsequent calls no longer trigger background fetches.
 
 ```dart
 Mixpanel mixpanel = await Mixpanel.init(

--- a/pages/docs/tracking-methods/sdks/swift/swift-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/swift/swift-flags.mdx
@@ -57,6 +57,82 @@ let options = MixpanelOptions(
 Mixpanel.initialize(token: "YOUR_PROJECT_TOKEN", options: options)
 ```
 
+## Flag Persistence
+
+Minimum supported SDK version: [`v6.4.0`](https://github.com/mixpanel/mixpanel-swift/releases/tag/v6.4.0)
+
+By default (`networkOnly`), the SDK fetches fresh flag assignments on app launch and waits for the network response before variant calls complete. You can enable persistence to persist assignments to UserDefaults so they are available immediately on subsequent launches.
+
+Configure a `variantLookupPolicy` on `FeatureFlagOptions`:
+
+**`networkFirst`** — The SDK waits for the network on every launch. If the network call fails, the persisted value is returned as a fallback. Async getter calls block until the fetch completes (or the fallback is resolved).
+
+```swift
+Mixpanel.initialize(token: "YOUR_PROJECT_TOKEN", options: MixpanelOptions(
+    featureFlagOptions: FeatureFlagOptions(
+        enabled: true,
+        variantLookupPolicy: .networkFirst()
+    )
+))
+
+// getVariantValue waits for the network. Falls back to persisted value if network fails.
+Mixpanel.mainInstance().flags.getVariantValue("my-feature-flag", fallbackValue: "control") { value in
+    // value is from the network response, or from persistence if the network was unavailable
+}
+```
+
+**`persistenceUntilNetworkSuccess`** — Persisted variants are returned immediately on launch. Each getter call while serving persisted data triggers a background network fetch (deduplicated — only one fetch runs at a time). If the fetch fails, persisted data continues to be served and the next getter call retries the fetch. Once a fetch succeeds, the in-memory state updates and subsequent calls no longer trigger background fetches.
+
+```swift
+Mixpanel.initialize(token: "YOUR_PROJECT_TOKEN", options: MixpanelOptions(
+    featureFlagOptions: FeatureFlagOptions(
+        enabled: true,
+        variantLookupPolicy: .persistenceUntilNetworkSuccess()
+    )
+))
+
+// getVariantValue returns immediately from persistence. Each call triggers a background fetch
+// until a network response succeeds and replaces the persisted state.
+Mixpanel.mainInstance().flags.getVariantValue("my-feature-flag", fallbackValue: "control") { value in
+    // value is from persistence; background fetch retries on each call until network succeeds
+}
+```
+
+To customize the TTL (default: 24 hours), pass a `TimeInterval`:
+
+```swift
+Mixpanel.initialize(token: "YOUR_PROJECT_TOKEN", options: MixpanelOptions(
+    featureFlagOptions: FeatureFlagOptions(
+        enabled: true,
+        variantLookupPolicy: .networkFirst(persistenceTtl: 12 * 3600) // 12 hours
+    )
+))
+```
+
+### Variant source
+
+Every `MixpanelFlagVariant` carries a `source` property indicating where the value came from: `.network`, `.persistence(persistedAt:)`, or `.fallback`. Use `getVariant()` to receive the full variant object.
+
+```swift
+let fallback = MixpanelFlagVariant(key: "control", value: "control")
+Mixpanel.mainInstance().flags.getVariant("my-feature-flag", fallback: fallback) { variant in
+    let value = variant.value
+    let source = variant.source // .network, .persistence(persistedAt:), or .fallback
+}
+```
+
+### `$experiment_started` properties
+
+When a variant is served, the `$experiment_started` exposure event includes:
+
+- `$variant_source` — `"network"` or `"persistence"`
+- `$persisted_at_in_ms` — epoch ms when the variant set was persisted *(persistence only)*
+- `$ttl_in_ms` — the configured TTL in ms *(persistence only)*
+
+<Callout type="info">
+Persisted variants are tied to the current `distinct_id`. Calling `identify()` with a new ID or calling `reset()` clears persisted data and triggers a fresh fetch.
+</Callout>
+
 ## Flag Reload
 
 Following initialization, you can reload feature flag assignments in a couple of ways:
@@ -85,6 +161,13 @@ Mixpanel.mainInstance().flags.setContext([
 ]) {
     // Flags have been re-fetched with the new context
 }
+```
+
+4) Calling `reset()` clears all feature flag assignments from memory and triggers a new fetch for the updated `distinct_id`. Requires SDK version [`v6.4.0`](https://github.com/mixpanel/mixpanel-swift/releases/tag/v6.4.0) or later.
+
+```swift
+Mixpanel.mainInstance().reset()
+// Flags are cleared immediately. A new fetch begins for the anonymous distinct_id.
 ```
 
 ## Deferred Flag Loading

--- a/pages/docs/tracking-methods/sdks/swift/swift-flags.mdx
+++ b/pages/docs/tracking-methods/sdks/swift/swift-flags.mdx
@@ -61,7 +61,7 @@ Mixpanel.initialize(token: "YOUR_PROJECT_TOKEN", options: options)
 
 Minimum supported SDK version: [`v6.4.0`](https://github.com/mixpanel/mixpanel-swift/releases/tag/v6.4.0)
 
-By default (`networkOnly`), the SDK fetches fresh flag assignments on app launch and waits for the network response before variant calls complete. You can enable persistence to persist assignments to UserDefaults so they are available immediately on subsequent launches.
+By default (`networkOnly`), the SDK fetches fresh flag assignments and waits for the network response before variant calls complete. You can enable persistence to persist assignments to UserDefaults so they are available immediately on subsequent launches.
 
 Configure a `variantLookupPolicy` on `FeatureFlagOptions`:
 


### PR DESCRIPTION
Adds persistence documentation to the main feature flag doc page at a high level, then samples for flutter, android, swift. JS & React Native will be added once released