### PR TITLE
Add Beta callout to Root Cause Analysis doc

### DIFF
--- a/pages/docs/root-cause-analysis.mdx
+++ b/pages/docs/root-cause-analysis.mdx
@@ -9,7 +9,7 @@ Investigating anomalies or trends in your data is extremely manual. Teams spend 
 Mixpanel's **AI-Powered Root Cause Analysis (RCA)** feature does that work for you. Launch RCA from any Insights report or fired alert and an AI agent automatically diagnoses what changed: it validates the anomaly, runs the relevant breakdowns, ranks the dimensions that contributed most, and writes up an interpretation with a confidence level and suggested next steps — all delivered as a Board you and your team can keep working from.
 
 <Callout type="info">
-    Root Cause Analysis is part of Mixpanel AI. Availability depends on your plan and feature configuration — if you don't see the option to run RCA, contact your Mixpanel account team.
+    Root Cause Analysis is in beta. If you'd like access, please reach out to your Mixpanel account team to join the waitlist.
 </Callout>
 
 ## How it works

--- a/pages/docs/root-cause-analysis.mdx
+++ b/pages/docs/root-cause-analysis.mdx
@@ -9,7 +9,7 @@ Investigating anomalies or trends in your data is extremely manual. Teams spend 
 Mixpanel's **AI-Powered Root Cause Analysis (RCA)** feature does that work for you. Launch RCA from any Insights report or fired alert and an AI agent automatically diagnoses what changed: it validates the anomaly, runs the relevant breakdowns, ranks the dimensions that contributed most, and writes up an interpretation with a confidence level and suggested next steps — all delivered as a Board you and your team can keep working from.
 
 <Callout type="info">
-    Root Cause Analysis is in beta. If you'd like access, please reach out to your Mixpanel account team to join the waitlist.
+    Root Cause Analysis is in Beta. If you'd like access, please reach out to your Mixpanel account team.
 </Callout>
 
 ## How it works


### PR DESCRIPTION
Mirror the Agentic Automations beta wording so the Beta status is prominent on the RCA support page.