### PR TITLE
[audit-log] new event type documentation

### DIFF
--- a/pages/docs/access-security/audit-log.mdx
+++ b/pages/docs/access-security/audit-log.mdx
@@ -33,211 +33,211 @@ Mixpanel tracks the following events in your Audit Log. The "Available Since" co
 
 ### Alerts
 
-| Event Type        | Display Name    | Description                               | Available Since      |
-| ----------------- | --------------- | ----------------------------------------- | -------------------- |
-| `alert.created`   | Alert Created   | A new alert was created on a report       | 2026-01-31T00:00:00Z |
-| `alert.deleted`   | Alert Deleted   | An alert was removed                      | 2026-01-31T00:00:00Z |
-| `alert.triggered` | Alert Triggered | An alert condition was met and triggered  | 2026-02-05T21:00:00Z |
-| `alert.updated`   | Alert Modified  | An existing alert's settings were changed | 2026-01-31T00:00:00Z |
+| Event Type        | Display Name    | Description                               | Available Since  |
+| ----------------- | --------------- | ----------------------------------------- | ---------------- |
+| `alert.created`   | Alert Created   | A new alert was created on a report       | February 1, 2026 |
+| `alert.deleted`   | Alert Deleted   | An alert was removed                      | February 1, 2026 |
+| `alert.triggered` | Alert Triggered | An alert condition was met and triggered  | February 7, 2026 |
+| `alert.updated`   | Alert Modified  | An existing alert's settings were changed | February 1, 2026 |
 
 ### Boards
 
-| Event Type                    | Display Name                | Description                                      | Available Since      |
-| ----------------------------- | --------------------------- | ------------------------------------------------ | -------------------- |
-| `board.created`               | Board Created               | A new board was created                          | 2026-04-03T19:00:00Z |
-| `board.deleted`               | Board Deleted               | A board was permanently removed                  | 2026-04-03T19:00:00Z |
-| `board.duplicated`            | Board Duplicated            | A copy of an existing board was created          | 2026-04-03T19:00:00Z |
-| `board.exported`              | Board Exported              | Board data was exported                          | 2026-04-03T19:00:00Z |
-| `board.public_access_updated` | Public Board Access Updated | Public sharing settings for a board were changed | 2026-04-03T19:00:00Z |
-| `board.shared`                | Board Shared                | A board was shared with users or teams           | 2026-04-03T19:00:00Z |
-| `board.unshared`              | Board Unshared              | Sharing access to a board was revoked            | 2026-04-03T19:00:00Z |
-| `board.updated`               | Board Updated               | Board settings or content were modified          | 2026-04-03T19:00:00Z |
+| Event Type                    | Display Name                | Description                                      | Available Since |
+| ----------------------------- | --------------------------- | ------------------------------------------------ | --------------- |
+| `board.created`               | Board Created               | A new board was created                          | April 5, 2026   |
+| `board.deleted`               | Board Deleted               | A board was permanently removed                  | April 5, 2026   |
+| `board.duplicated`            | Board Duplicated            | A copy of an existing board was created          | April 5, 2026   |
+| `board.exported`              | Board Exported              | Board data was exported                          | April 5, 2026   |
+| `board.public_access_updated` | Public Board Access Updated | Public sharing settings for a board were changed | April 5, 2026   |
+| `board.shared`                | Board Shared                | A board was shared with users or teams           | April 5, 2026   |
+| `board.unshared`              | Board Unshared              | Sharing access to a board was revoked            | April 5, 2026   |
+| `board.updated`               | Board Updated               | Board settings or content were modified          | April 5, 2026   |
 
 ### Board Subscriptions
 
-| Event Type                   | Display Name               | Description                                     | Available Since      |
-| ---------------------------- | -------------------------- | ----------------------------------------------- | -------------------- |
-| `board_subscription.created` | Board Subscription Created | A scheduled board email subscription was set up | 2026-04-03T19:00:00Z |
-| `board_subscription.deleted` | Board Subscription Deleted | A board subscription was removed                | 2026-04-03T19:00:00Z |
+| Event Type                   | Display Name               | Description                                     | Available Since |
+| ---------------------------- | -------------------------- | ----------------------------------------------- | --------------- |
+| `board_subscription.created` | Board Subscription Created | A scheduled board email subscription was set up | April 5, 2026   |
+| `board_subscription.deleted` | Board Subscription Deleted | A board subscription was removed                | April 5, 2026   |
 
 ### Reports
 
-| Event Type                       | Display Name                 | Description                                      | Available Since      |
-| -------------------------------- | ---------------------------- | ------------------------------------------------ | -------------------- |
-| `bookmark.created`               | Report Created               | A new saved report was created                   | 2026-04-03T19:00:00Z |
-| `bookmark.deleted`               | Report Deleted               | A saved report was removed                       | 2026-04-03T19:00:00Z |
-| `bookmark.moved`                 | Report Moved                 | A saved report was moved to a different location | 2026-05-18T19:00:00Z |
-| `bookmark.screenshot_downloaded` | Report Screenshot Downloaded | A screenshot of a report was downloaded          | 2026-05-18T19:00:00Z |
-| `bookmark.updated`               | Report Updated               | A saved report's configuration was changed       | 2026-04-03T19:00:00Z |
+| Event Type                       | Display Name                 | Description                                      | Available Since |
+| -------------------------------- | ---------------------------- | ------------------------------------------------ | --------------- |
+| `bookmark.created`               | Report Created               | A new saved report was created                   | April 5, 2026   |
+| `bookmark.deleted`               | Report Deleted               | A saved report was removed                       | April 5, 2026   |
+| `bookmark.moved`                 | Report Moved                 | A saved report was moved to a different location | May 20, 2026    |
+| `bookmark.screenshot_downloaded` | Report Screenshot Downloaded | A screenshot of a report was downloaded          | May 20, 2026    |
+| `bookmark.updated`               | Report Updated               | A saved report's configuration was changed       | April 5, 2026   |
 
 ### Cohorts
 
-| Event Type        | Display Name    | Description                               | Available Since      |
-| ----------------- | --------------- | ----------------------------------------- | -------------------- |
-| `cohort.created`  | Cohort Created  | A new cohort was created                  | 2026-04-03T19:00:00Z |
-| `cohort.deleted`  | Cohort Deleted  | A cohort was removed                      | 2026-04-03T19:00:00Z |
-| `cohort.shared`   | Cohort Shared   | A cohort was shared with users or teams   | 2026-04-03T19:00:00Z |
-| `cohort.unshared` | Cohort Unshared | Sharing access to a cohort was revoked    | 2026-04-03T19:00:00Z |
-| `cohort.updated`  | Cohort Updated  | Cohort criteria or settings were modified | 2026-04-03T19:00:00Z |
+| Event Type        | Display Name    | Description                               | Available Since |
+| ----------------- | --------------- | ----------------------------------------- | --------------- |
+| `cohort.created`  | Cohort Created  | A new cohort was created                  | April 5, 2026   |
+| `cohort.deleted`  | Cohort Deleted  | A cohort was removed                      | April 5, 2026   |
+| `cohort.shared`   | Cohort Shared   | A cohort was shared with users or teams   | April 5, 2026   |
+| `cohort.unshared` | Cohort Unshared | Sharing access to a cohort was revoked    | April 5, 2026   |
+| `cohort.updated`  | Cohort Updated  | Cohort criteria or settings were modified | April 5, 2026   |
 
 ### Cohort Syncs
 
-| Event Type            | Display Name        | Description                                  | Available Since      |
-| --------------------- | ------------------- | -------------------------------------------- | -------------------- |
-| `cohort_sync.created` | Cohort Sync Created | A new cohort sync integration was configured | 2026-05-18T19:00:00Z |
-| `cohort_sync.updated` | Cohort Sync Updated | Cohort sync settings were modified           | 2026-05-18T19:00:00Z |
+| Event Type            | Display Name        | Description                                  | Available Since |
+| --------------------- | ------------------- | -------------------------------------------- | --------------- |
+| `cohort_sync.created` | Cohort Sync Created | A new cohort sync integration was configured | May 20, 2026    |
+| `cohort_sync.updated` | Cohort Sync Updated | Cohort sync settings were modified           | May 20, 2026    |
 
 ### Data Pipelines
 
-| Event Type              | Display Name          | Description                                | Available Since      |
-| ----------------------- | --------------------- | ------------------------------------------ | -------------------- |
-| `data_pipeline.created` | Data Pipeline Created | A new data pipeline integration was set up | 2026-04-03T19:00:00Z |
-| `data_pipeline.deleted` | Data Pipeline Deleted | A data pipeline was removed                | 2026-04-03T19:00:00Z |
-| `data_pipeline.updated` | Data Pipeline Updated | Data pipeline configuration was modified   | 2026-04-03T19:00:00Z |
+| Event Type              | Display Name          | Description                                | Available Since |
+| ----------------------- | --------------------- | ------------------------------------------ | --------------- |
+| `data_pipeline.created` | Data Pipeline Created | A new data pipeline integration was set up | April 5, 2026   |
+| `data_pipeline.deleted` | Data Pipeline Deleted | A data pipeline was removed                | April 5, 2026   |
+| `data_pipeline.updated` | Data Pipeline Updated | Data pipeline configuration was modified   | April 5, 2026   |
 
 ### Warehouse Sources
 
-| Event Type                      | Display Name                  | Description                                      | Available Since      |
-| ------------------------------- | ----------------------------- | ------------------------------------------------ | -------------------- |
-| `warehouse_source.created`      | Warehouse Source Created      | A new warehouse data source was connected        | 2026-04-03T19:00:00Z |
-| `warehouse_source.deleted`      | Warehouse Source Deleted      | A warehouse source connection was removed        | 2026-04-03T19:00:00Z |
-| `warehouse_source.updated`      | Warehouse Source Updated      | Warehouse source configuration was changed       | 2026-04-03T19:00:00Z |
-| `warehouse_source_sync.created` | Warehouse Source Sync Created | A warehouse source sync job was created          | 2026-05-18T19:00:00Z |
-| `warehouse_source_sync.deleted` | Warehouse Source Sync Deleted | A warehouse source sync job was deleted          | 2026-05-18T19:00:00Z |
-| `warehouse_source_sync.updated` | Warehouse Source Sync Updated | Warehouse source sync configuration was modified | 2026-05-18T19:00:00Z |
+| Event Type                      | Display Name                  | Description                                      | Available Since |
+| ------------------------------- | ----------------------------- | ------------------------------------------------ | --------------- |
+| `warehouse_source.created`      | Warehouse Source Created      | A new warehouse data source was connected        | April 5, 2026   |
+| `warehouse_source.deleted`      | Warehouse Source Deleted      | A warehouse source connection was removed        | April 5, 2026   |
+| `warehouse_source.updated`      | Warehouse Source Updated      | Warehouse source configuration was changed       | April 5, 2026   |
+| `warehouse_source_sync.created` | Warehouse Source Sync Created | A warehouse source sync job was created          | May 20, 2026    |
+| `warehouse_source_sync.deleted` | Warehouse Source Sync Deleted | A warehouse source sync job was deleted          | May 20, 2026    |
+| `warehouse_source_sync.updated` | Warehouse Source Sync Updated | Warehouse source sync configuration was modified | May 20, 2026    |
 
 ### Data Management
 
-| Event Type                    | Display Name                 | Description                                         | Available Since      |
-| ----------------------------- | ---------------------------- | --------------------------------------------------- | -------------------- |
-| `event_definition.created`    | Event Definition Created     | A new event definition was created                  | 2026-05-18T19:00:00Z |
-| `event_definition.deleted`    | Event Definition Deleted     | An event definition was deleted                     | 2026-05-18T19:00:00Z |
-| `event_definition.updated`    | Event Definition Updated     | An event definition was modified                    | 2026-05-18T19:00:00Z |
-| `event_deletion.canceled`     | Event Deletion Canceled      | A pending event deletion request was canceled       | 2026-04-03T19:00:00Z |
-| `event_deletion.created`      | Event Deletion Requested     | A request to delete events was submitted            | 2026-04-03T19:00:00Z |
-| `profile.deleted`             | Profile Deleted              | A user profile was removed                          | 2026-05-18T19:00:00Z |
-| `profile.updated`             | Profile Updated              | A user profile was updated                          | 2026-05-18T19:00:00Z |
-| `property_definition.created` | Property Definition Created  | A new property definition was created               | 2026-05-18T19:00:00Z |
-| `property_definition.updated` | Property Definition Updated  | A property definition was modified                  | 2026-05-18T19:00:00Z |
-| `user_data_deletion.canceled` | User Data Deletion Canceled  | A pending user data deletion request was canceled   | 2026-04-03T19:00:00Z |
-| `user_data_deletion.created`  | User Data Deletion Requested | A request to delete user profile data was submitted | 2026-04-03T19:00:00Z |
+| Event Type                    | Display Name                 | Description                                         | Available Since |
+| ----------------------------- | ---------------------------- | --------------------------------------------------- | --------------- |
+| `event_definition.created`    | Event Definition Created     | A new event definition was created                  | May 20, 2026    |
+| `event_definition.deleted`    | Event Definition Deleted     | An event definition was deleted                     | May 20, 2026    |
+| `event_definition.updated`    | Event Definition Updated     | An event definition was modified                    | May 20, 2026    |
+| `event_deletion.canceled`     | Event Deletion Canceled      | A pending event deletion request was canceled       | April 5, 2026   |
+| `event_deletion.created`      | Event Deletion Requested     | A request to delete events was submitted            | April 5, 2026   |
+| `profile.deleted`             | Profile Deleted              | A user profile was removed                          | May 20, 2026    |
+| `profile.updated`             | Profile Updated              | A user profile was updated                          | May 20, 2026    |
+| `property_definition.created` | Property Definition Created  | A new property definition was created               | May 20, 2026    |
+| `property_definition.updated` | Property Definition Updated  | A property definition was modified                  | May 20, 2026    |
+| `user_data_deletion.canceled` | User Data Deletion Canceled  | A pending user data deletion request was canceled   | April 5, 2026   |
+| `user_data_deletion.created`  | User Data Deletion Requested | A request to delete user profile data was submitted | April 5, 2026   |
 
 > **Note:** Profile updates (`profile.deleted`, `profile.updated`) are only tracked when initiated through the Mixpanel web application. API calls and direct updates using the Mixpanel SDK are not currently logged in the audit log.
 
 ### Data Exports
 
-| Event Type                    | Display Name                | Description                              | Available Since      |
-| ----------------------------- | --------------------------- | ---------------------------------------- | -------------------- |
-| `audit_log_export.created`    | Audit Log Export Created    | An audit log export was initiated        | 2026-04-03T19:00:00Z |
-| `audit_log_export.downloaded` | Audit Log Export Downloaded | An audit log export file was downloaded  | 2026-04-03T19:00:00Z |
-| `event_export.downloaded`     | Events Exported             | Event data was exported from the project | 2026-04-03T19:00:00Z |
-| `profile_export.downloaded`   | Profile Data Exported       | User profile data was exported           | 2026-04-03T19:00:00Z |
-| `raw_event_export.requested`  | Raw Event Export Requested  | A raw event export was requested         | 2026-05-18T19:00:00Z |
-| `user_data_export.created`    | User Data Export Requested  | A user data export request was submitted | 2026-04-03T19:00:00Z |
+| Event Type                    | Display Name                | Description                              | Available Since |
+| ----------------------------- | --------------------------- | ---------------------------------------- | --------------- |
+| `audit_log_export.created`    | Audit Log Export Created    | An audit log export was initiated        | April 5, 2026   |
+| `audit_log_export.downloaded` | Audit Log Export Downloaded | An audit log export file was downloaded  | April 5, 2026   |
+| `event_export.downloaded`     | Events Exported             | Event data was exported from the project | April 5, 2026   |
+| `profile_export.downloaded`   | Profile Data Exported       | User profile data was exported           | April 5, 2026   |
+| `raw_event_export.requested`  | Raw Event Export Requested  | A raw event export was requested         | May 20, 2026    |
+| `user_data_export.created`    | User Data Export Requested  | A user data export request was submitted | April 5, 2026   |
 
 ### Service Accounts
 
-| Event Type                             | Display Name                         | Description                                           | Scope             | Available Since      |
-| -------------------------------------- | ------------------------------------ | ----------------------------------------------------- | ----------------- | -------------------- |
-| `service_account.added_to_project`     | Service Account Added to Project     | A service account was granted access to a project     | Both              | 2026-04-03T19:00:00Z |
-| `service_account.created`              | Service Account Created              | A new service account was created                     | Organization only | 2026-04-03T19:00:00Z |
-| `service_account.deleted`              | Service Account Deleted              | A service account was removed                         | Organization only | 2026-04-03T19:00:00Z |
-| `service_account.removed_from_project` | Service Account Removed from Project | A service account's project access was revoked        | Both              | 2026-04-03T19:00:00Z |
-| `service_account.role_changed`         | Service Account Role Changed         | A service account's role or permissions were modified | Both              | 2026-04-03T19:00:00Z |
+| Event Type                             | Display Name                         | Description                                           | Scope             | Available Since |
+| -------------------------------------- | ------------------------------------ | ----------------------------------------------------- | ----------------- | --------------- |
+| `service_account.added_to_project`     | Service Account Added to Project     | A service account was granted access to a project     | Both              | April 5, 2026   |
+| `service_account.created`              | Service Account Created              | A new service account was created                     | Organization only | April 5, 2026   |
+| `service_account.deleted`              | Service Account Deleted              | A service account was removed                         | Organization only | April 5, 2026   |
+| `service_account.removed_from_project` | Service Account Removed from Project | A service account's project access was revoked        | Both              | April 5, 2026   |
+| `service_account.role_changed`         | Service Account Role Changed         | A service account's role or permissions were modified | Both              | April 5, 2026   |
 
 ### User Authentication
 
-| Event Type               | Display Name                 | Description                                      | Scope             | Available Since      |
-| ------------------------ | ---------------------------- | ------------------------------------------------ | ----------------- | -------------------- |
-| `session.logged_in`      | User Logged In               | A user successfully logged into the organization | Organization only | 2026-04-03T19:00:00Z |
-| `session.logged_out`     | User Logged Out              | A user logged out of the organization            | Organization only | 2026-04-03T19:00:00Z |
-| `session.login_failed`   | User Login Failed            | A user login attempt failed                      | Organization only | 2026-05-18T19:00:00Z |
-| `user.twofactor_enabled` | User Enabled Two-Factor Auth | A user activated two-factor authentication       | Organization only | 2026-04-03T19:00:00Z |
+| Event Type               | Display Name                 | Description                                      | Scope             | Available Since |
+| ------------------------ | ---------------------------- | ------------------------------------------------ | ----------------- | --------------- |
+| `session.logged_in`      | User Logged In               | A user successfully logged into the organization | Organization only | April 5, 2026   |
+| `session.logged_out`     | User Logged Out              | A user logged out of the organization            | Organization only | April 5, 2026   |
+| `session.login_failed`   | User Login Failed            | A user login attempt failed                      | Organization only | May 20, 2026    |
+| `user.twofactor_enabled` | User Enabled Two-Factor Auth | A user activated two-factor authentication       | Organization only | April 5, 2026   |
 
 ### Billing Info
 
-| Event Type                                 | Display Name                        | Description                              | Scope             | Available Since      |
-| ------------------------------------------ | ----------------------------------- | ---------------------------------------- | ----------------- | -------------------- |
-| `billing_info.payment_info_updated`        | Billing Payment Information Updated | Billing payment information was modified | Organization only | 2026-05-18T19:00:00Z |
-| `billing_info.receipt_preferences_updated` | Billing Invoice Preferences Updated | Billing invoice preferences were updated | Organization only | 2026-05-18T19:00:00Z |
-| `billing_info.tax_info_updated`            | Billing Tax Information Updated     | Billing tax information was modified     | Organization only | 2026-05-18T19:00:00Z |
+| Event Type                                 | Display Name                        | Description                              | Scope             | Available Since |
+| ------------------------------------------ | ----------------------------------- | ---------------------------------------- | ----------------- | --------------- |
+| `billing_info.payment_info_updated`        | Billing Payment Information Updated | Billing payment information was modified | Organization only | May 20, 2026    |
+| `billing_info.receipt_preferences_updated` | Billing Invoice Preferences Updated | Billing invoice preferences were updated | Organization only | May 20, 2026    |
+| `billing_info.tax_info_updated`            | Billing Tax Information Updated     | Billing tax information was modified     | Organization only | May 20, 2026    |
 
 ### Experiments
 
-| Event Type              | Display Name                 | Description                          | Available Since      |
-| ----------------------- | ---------------------------- | ------------------------------------ | -------------------- |
-| `experiment.archived`   | Experiment Archived          | An experiment was archived           | 2026-05-18T19:00:00Z |
-| `experiment.concluded`  | Experiment Concluded         | An experiment was concluded          | 2026-05-18T19:00:00Z |
-| `experiment.created`    | Experiment Created           | A new experiment was created         | 2026-05-18T19:00:00Z |
-| `experiment.decided`    | Experiment Decision Recorded | A decision was made on an experiment | 2026-05-18T19:00:00Z |
-| `experiment.deleted`    | Experiment Deleted           | An experiment was deleted            | 2026-05-18T19:00:00Z |
-| `experiment.duplicated` | Experiment Duplicated        | An experiment was duplicated         | 2026-05-18T19:00:00Z |
-| `experiment.launched`   | Experiment Launched          | An experiment was launched           | 2026-05-18T19:00:00Z |
-| `experiment.restored`   | Experiment Restored          | An archived experiment was restored  | 2026-05-18T19:00:00Z |
-| `experiment.updated`    | Experiment Updated           | Experiment settings were modified    | 2026-05-18T19:00:00Z |
+| Event Type              | Display Name                 | Description                          | Available Since |
+| ----------------------- | ---------------------------- | ------------------------------------ | --------------- |
+| `experiment.archived`   | Experiment Archived          | An experiment was archived           | May 20, 2026    |
+| `experiment.concluded`  | Experiment Concluded         | An experiment was concluded          | May 20, 2026    |
+| `experiment.created`    | Experiment Created           | A new experiment was created         | May 20, 2026    |
+| `experiment.decided`    | Experiment Decision Recorded | A decision was made on an experiment | May 20, 2026    |
+| `experiment.deleted`    | Experiment Deleted           | An experiment was deleted            | May 20, 2026    |
+| `experiment.duplicated` | Experiment Duplicated        | An experiment was duplicated         | May 20, 2026    |
+| `experiment.launched`   | Experiment Launched          | An experiment was launched           | May 20, 2026    |
+| `experiment.restored`   | Experiment Restored          | An archived experiment was restored  | May 20, 2026    |
+| `experiment.updated`    | Experiment Updated           | Experiment settings were modified    | May 20, 2026    |
 
 ### Feature Flags
 
-| Event Type                | Display Name            | Description                           | Available Since      |
-| ------------------------- | ----------------------- | ------------------------------------- | -------------------- |
-| `feature_flag.archived`   | Feature Flag Archived   | A feature flag was archived           | 2026-05-18T19:00:00Z |
-| `feature_flag.created`    | Feature Flag Created    | A new feature flag was created        | 2026-05-18T19:00:00Z |
-| `feature_flag.deleted`    | Feature Flag Deleted    | A feature flag was deleted            | 2026-05-18T19:00:00Z |
-| `feature_flag.duplicated` | Feature Flag Duplicated | A feature flag was duplicated         | 2026-05-18T19:00:00Z |
-| `feature_flag.restored`   | Feature Flag Restored   | An archived feature flag was restored | 2026-05-18T19:00:00Z |
-| `feature_flag.updated`    | Feature Flag Updated    | Feature flag settings were modified   | 2026-05-18T19:00:00Z |
+| Event Type                | Display Name            | Description                           | Available Since |
+| ------------------------- | ----------------------- | ------------------------------------- | --------------- |
+| `feature_flag.archived`   | Feature Flag Archived   | A feature flag was archived           | May 20, 2026    |
+| `feature_flag.created`    | Feature Flag Created    | A new feature flag was created        | May 20, 2026    |
+| `feature_flag.deleted`    | Feature Flag Deleted    | A feature flag was deleted            | May 20, 2026    |
+| `feature_flag.duplicated` | Feature Flag Duplicated | A feature flag was duplicated         | May 20, 2026    |
+| `feature_flag.restored`   | Feature Flag Restored   | An archived feature flag was restored | May 20, 2026    |
+| `feature_flag.updated`    | Feature Flag Updated    | Feature flag settings were modified   | May 20, 2026    |
 
 ### Organization Settings
 
-| Event Type                                        | Display Name                          | Description                                              | Scope             | Available Since      |
-| ------------------------------------------------- | ------------------------------------- | -------------------------------------------------------- | ----------------- | -------------------- |
-| `organization_access_security.twofactor_disabled` | Organization Two-Factor Auth Disabled | Organization-wide two-factor authentication was disabled | Organization only | 2026-05-18T19:00:00Z |
-| `organization_access_security.twofactor_enabled`  | Organization Two-Factor Auth Enabled  | Organization-wide two-factor authentication was enabled  | Organization only | 2026-05-18T19:00:00Z |
-| `organization_setting.updated`                    | Organization Settings Changed         | Organization settings were modified                      | Organization only | 2026-05-18T19:00:00Z |
-| `organization_spark_setting.updated`              | Organization AI Settings Changed      | Organization AI settings were updated                    | Organization only | 2026-05-18T19:00:00Z |
+| Event Type                                        | Display Name                          | Description                                              | Scope             | Available Since |
+| ------------------------------------------------- | ------------------------------------- | -------------------------------------------------------- | ----------------- | --------------- |
+| `organization_access_security.twofactor_disabled` | Organization Two-Factor Auth Disabled | Organization-wide two-factor authentication was disabled | Organization only | May 20, 2026    |
+| `organization_access_security.twofactor_enabled`  | Organization Two-Factor Auth Enabled  | Organization-wide two-factor authentication was enabled  | Organization only | May 20, 2026    |
+| `organization_setting.updated`                    | Organization Settings Changed         | Organization settings were modified                      | Organization only | May 20, 2026    |
+| `organization_spark_setting.updated`              | Organization AI Settings Changed      | Organization AI settings were updated                    | Organization only | May 20, 2026    |
 
 ### Project Settings
 
-| Event Type            | Display Name        | Description                                                    | Available Since      |
-| --------------------- | ------------------- | -------------------------------------------------------------- | -------------------- |
-| `project.transferred` | Project Transferred | A project was transferred to a different organization or owner | 2026-05-18T19:00:00Z |
+| Event Type            | Display Name        | Description                                                    | Available Since |
+| --------------------- | ------------------- | -------------------------------------------------------------- | --------------- |
+| `project.transferred` | Project Transferred | A project was transferred to a different organization or owner | May 20, 2026    |
 
 ### Teams
 
-| Event Type                     | Display Name                      | Description                               | Scope             | Available Since      |
-| ------------------------------ | --------------------------------- | ----------------------------------------- | ----------------- | -------------------- |
-| `team.created`                 | Team Created                      | A new team was created                    | Organization only | 2026-05-18T19:00:00Z |
-| `team.deleted`                 | Team Deleted                      | A team was deleted                        | Organization only | 2026-05-18T19:00:00Z |
-| `team.service_account_added`   | Service Account Added to Team     | A service account was added to a team     | Organization only | 2026-05-18T19:00:00Z |
-| `team.service_account_removed` | Service Account Removed from Team | A service account was removed from a team | Organization only | 2026-05-18T19:00:00Z |
-| `team.updated`                 | Team Updated                      | Team settings were modified               | Organization only | 2026-05-18T19:00:00Z |
-| `team.user_added`              | User Added to Team                | A user was added to a team                | Organization only | 2026-05-18T19:00:00Z |
-| `team.user_removed`            | User Removed from Team            | A user was removed from a team            | Organization only | 2026-05-18T19:00:00Z |
+| Event Type                     | Display Name                      | Description                               | Scope             | Available Since |
+| ------------------------------ | --------------------------------- | ----------------------------------------- | ----------------- | --------------- |
+| `team.created`                 | Team Created                      | A new team was created                    | Organization only | May 20, 2026    |
+| `team.deleted`                 | Team Deleted                      | A team was deleted                        | Organization only | May 20, 2026    |
+| `team.service_account_added`   | Service Account Added to Team     | A service account was added to a team     | Organization only | May 20, 2026    |
+| `team.service_account_removed` | Service Account Removed from Team | A service account was removed from a team | Organization only | May 20, 2026    |
+| `team.updated`                 | Team Updated                      | Team settings were modified               | Organization only | May 20, 2026    |
+| `team.user_added`              | User Added to Team                | A user was added to a team                | Organization only | May 20, 2026    |
+| `team.user_removed`            | User Removed from Team            | A user was removed from a team            | Organization only | May 20, 2026    |
 
 ### User Management
 
-| Event Type                       | Display Name                   | Description                                           | Scope             | Available Since      |
-| -------------------------------- | ------------------------------ | ----------------------------------------------------- | ----------------- | -------------------- |
-| `invitation.accepted`            | Accepted Invitation            | A user accepted an invitation to the organization     | Organization only | 2026-05-18T19:00:00Z |
-| `invitation.sent`                | Invited User to Organization   | An invitation was sent to a new user                  | Organization only | 2026-05-18T19:00:00Z |
-| `organization.user_added`        | User Added to Organization     | A user was added to the organization                  | Organization only | 2026-05-18T19:00:00Z |
-| `organization.user_removed`      | User Removed from Organization | A user was removed from the organization              | Organization only | 2026-05-18T19:00:00Z |
-| `project.default_access_granted` | Default Project Access Granted | Default access for all users to a project was granted | Both              | 2026-05-18T19:00:00Z |
-| `project.default_access_revoked` | Default Project Access Revoked | Default access for all users to a project was revoked | Both              | 2026-05-18T19:00:00Z |
-| `project.team_added`             | Team Added to Project          | A team was granted access to a project                | Both              | 2026-05-18T19:00:00Z |
-| `project.team_removed`           | Team Removed from Project      | A team's project access was revoked                   | Both              | 2026-05-18T19:00:00Z |
-| `project.user_added`             | User Added to Project          | A user was granted access to a project                | Both              | 2026-05-18T19:00:00Z |
-| `project.user_removed`           | User Removed from Project      | A user's project access was revoked                   | Both              | 2026-05-18T19:00:00Z |
-| `user.role_changed`              | User Role Changed              | A user's role or permissions were modified            | Both              | 2026-05-18T19:00:00Z |
+| Event Type                       | Display Name                   | Description                                           | Scope             | Available Since |
+| -------------------------------- | ------------------------------ | ----------------------------------------------------- | ----------------- | --------------- |
+| `invitation.accepted`            | Accepted Invitation            | A user accepted an invitation to the organization     | Organization only | May 20, 2026    |
+| `invitation.sent`                | Invited User to Organization   | An invitation was sent to a new user                  | Organization only | May 20, 2026    |
+| `organization.user_added`        | User Added to Organization     | A user was added to the organization                  | Organization only | May 20, 2026    |
+| `organization.user_removed`      | User Removed from Organization | A user was removed from the organization              | Organization only | May 20, 2026    |
+| `project.default_access_granted` | Default Project Access Granted | Default access for all users to a project was granted | Both              | May 20, 2026    |
+| `project.default_access_revoked` | Default Project Access Revoked | Default access for all users to a project was revoked | Both              | May 20, 2026    |
+| `project.team_added`             | Team Added to Project          | A team was granted access to a project                | Both              | May 20, 2026    |
+| `project.team_removed`           | Team Removed from Project      | A team's project access was revoked                   | Both              | May 20, 2026    |
+| `project.user_added`             | User Added to Project          | A user was granted access to a project                | Both              | May 20, 2026    |
+| `project.user_removed`           | User Removed from Project      | A user's project access was revoked                   | Both              | May 20, 2026    |
+| `user.role_changed`              | User Role Changed              | A user's role or permissions were modified            | Both              | May 20, 2026    |
 
 ### Workspaces
 
-| Event Type               | Display Name                | Description                              | Available Since      |
-| ------------------------ | --------------------------- | ---------------------------------------- | -------------------- |
-| `workspace.team_added`   | Team Added to Data View     | A team was granted access to a data view | 2026-05-18T19:00:00Z |
-| `workspace.team_removed` | Team Removed from Data View | A team's data view access was revoked    | 2026-05-18T19:00:00Z |
-| `workspace.user_added`   | User Added to Data View     | A user was granted access to a data view | 2026-05-18T19:00:00Z |
-| `workspace.user_removed` | User Removed from Data View | A user's data view access was revoked    | 2026-05-18T19:00:00Z |
+| Event Type               | Display Name                | Description                              | Available Since |
+| ------------------------ | --------------------------- | ---------------------------------------- | --------------- |
+| `workspace.team_added`   | Team Added to Data View     | A team was granted access to a data view | May 20, 2026    |
+| `workspace.team_removed` | Team Removed from Data View | A team's data view access was revoked    | May 20, 2026    |
+| `workspace.user_added`   | User Added to Data View     | A user was granted access to a data view | May 20, 2026    |
+| `workspace.user_removed` | User Removed from Data View | A user's data view access was revoked    | May 20, 2026    |
 
 ## Exporting Audit Log
 

--- a/pages/docs/access-security/audit-log.mdx
+++ b/pages/docs/access-security/audit-log.mdx
@@ -1,11 +1,13 @@
-import { Callout } from 'nextra/components'
+import { Callout } from "nextra/components";
 
 # Audit Log
 
 Mixpanel's Audit Log tracks activity within your organization and projects, providing visibility into who made changes, when they occurred, and what was modified. Audit log helps teams maintain security, troubleshoot issues, and meet compliance requirements.
 
 <Callout type="info">
-    Audit log is available on all plans. Free and Growth plans retain logs for 90 days. Enterprise plans retain logs for 2 years. See our [pricing page](https://mixpanel.com/pricing/) for more details.
+  Audit log is available on all plans. Free and Growth plans retain logs for 90
+  days. Enterprise plans retain logs for 2 years. See our [pricing
+  page](https://mixpanel.com/pricing/) for more details.
 </Callout>
 
 ## Accessing Audit Log
@@ -25,121 +27,217 @@ Some events are tracked only at the organization level, while most are available
 
 ## Tracked Events
 
-The current audit logging contains only actions made within the Mixpanel UI. Each line in the UI will contain information on the Date and Time, User, Action, IP and Project or Org if available. Clicking on each log item you'll be able to see a raw view with additional information.  Logging for each set of events starts on the following dates:
-- **Alerts** - 2026-01-31T00:00:00Z
-- **Boards** - 2026-04-03T19:00:00Z
-- **Board Subscriptions** - 2026-04-03T19:00:00Z
-- **Reports** - 2026-04-03T19:00:00Z
-- **Cohorts** - 2026-04-03T19:00:00Z
-- **Data Pipelines** - 2026-04-03T19:00:00Z
-- **Warehouse Sources** - 2026-04-03T19:00:00Z
-- **Data Management** - 2026-04-03T19:00:00Z
-- **Data Exports** - 2026-04-03T19:00:00Z
-- **Service Accounts** - 2026-04-03T19:00:00Z
-- **User Authentication** - 2026-04-03T19:00:00Z
+The current audit logging contains only actions made within the Mixpanel UI. Each line in the UI will contain information on the Date and Time, User, Action, IP and Project or Org if available. Clicking on each log item you'll be able to see a raw view with additional information.
 
-Mixpanel tracks the following events in your Audit Log:
+Mixpanel tracks the following events in your Audit Log. The "Available Since" column indicates when audit logging began for each event type:
 
 ### Alerts
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `alert.created` | Alert Created | A new alert was created on a report |
-| `alert.deleted` | Alert Deleted | An alert was removed |
-| `alert.triggered` | Alert Triggered | An alert condition was met and triggered |
-| `alert.updated` | Alert Modified | An existing alert's settings were changed |
+| Event Type        | Display Name    | Description                               | Available Since      |
+| ----------------- | --------------- | ----------------------------------------- | -------------------- |
+| `alert.created`   | Alert Created   | A new alert was created on a report       | 2026-01-31T00:00:00Z |
+| `alert.deleted`   | Alert Deleted   | An alert was removed                      | 2026-01-31T00:00:00Z |
+| `alert.triggered` | Alert Triggered | An alert condition was met and triggered  | 2026-02-05T21:00:00Z |
+| `alert.updated`   | Alert Modified  | An existing alert's settings were changed | 2026-01-31T00:00:00Z |
 
 ### Boards
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `board.created` | Board Created | A new board was created |
-| `board.deleted` | Board Deleted | A board was permanently removed |
-| `board.duplicated` | Board Duplicated | A copy of an existing board was created |
-| `board.exported` | Board Exported | Board data was exported |
-| `board.public_access_updated` | Public Board Access Updated | Public sharing settings for a board were changed |
-| `board.shared` | Board Shared | A board was shared with users or teams |
-| `board.unshared` | Board Unshared | Sharing access to a board was revoked |
-| `board.updated` | Board Updated | Board settings or content were modified |
+| Event Type                    | Display Name                | Description                                      | Available Since      |
+| ----------------------------- | --------------------------- | ------------------------------------------------ | -------------------- |
+| `board.created`               | Board Created               | A new board was created                          | 2026-04-03T19:00:00Z |
+| `board.deleted`               | Board Deleted               | A board was permanently removed                  | 2026-04-03T19:00:00Z |
+| `board.duplicated`            | Board Duplicated            | A copy of an existing board was created          | 2026-04-03T19:00:00Z |
+| `board.exported`              | Board Exported              | Board data was exported                          | 2026-04-03T19:00:00Z |
+| `board.public_access_updated` | Public Board Access Updated | Public sharing settings for a board were changed | 2026-04-03T19:00:00Z |
+| `board.shared`                | Board Shared                | A board was shared with users or teams           | 2026-04-03T19:00:00Z |
+| `board.unshared`              | Board Unshared              | Sharing access to a board was revoked            | 2026-04-03T19:00:00Z |
+| `board.updated`               | Board Updated               | Board settings or content were modified          | 2026-04-03T19:00:00Z |
 
 ### Board Subscriptions
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `board_subscription.created` | Board Subscription Created | A scheduled board email subscription was set up |
-| `board_subscription.deleted` | Board Subscription Deleted | A board subscription was removed |
+| Event Type                   | Display Name               | Description                                     | Available Since      |
+| ---------------------------- | -------------------------- | ----------------------------------------------- | -------------------- |
+| `board_subscription.created` | Board Subscription Created | A scheduled board email subscription was set up | 2026-04-03T19:00:00Z |
+| `board_subscription.deleted` | Board Subscription Deleted | A board subscription was removed                | 2026-04-03T19:00:00Z |
 
 ### Reports
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `bookmark.created` | Report Created | A new saved report was created |
-| `bookmark.deleted` | Report Deleted | A saved report was removed |
-| `bookmark.updated` | Report Updated | A saved report's configuration was changed |
+| Event Type                       | Display Name                 | Description                                      | Available Since      |
+| -------------------------------- | ---------------------------- | ------------------------------------------------ | -------------------- |
+| `bookmark.created`               | Report Created               | A new saved report was created                   | 2026-04-03T19:00:00Z |
+| `bookmark.deleted`               | Report Deleted               | A saved report was removed                       | 2026-04-03T19:00:00Z |
+| `bookmark.moved`                 | Report Moved                 | A saved report was moved to a different location | 2026-05-18T19:00:00Z |
+| `bookmark.screenshot_downloaded` | Report Screenshot Downloaded | A screenshot of a report was downloaded          | 2026-05-18T19:00:00Z |
+| `bookmark.updated`               | Report Updated               | A saved report's configuration was changed       | 2026-04-03T19:00:00Z |
 
 ### Cohorts
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `cohort.created` | Cohort Created | A new cohort was created |
-| `cohort.deleted` | Cohort Deleted | A cohort was permanently removed |
-| `cohort.shared` | Cohort Shared | A cohort was shared with users or teams |
-| `cohort.unshared` | Cohort Unshared | Sharing access to a cohort was revoked |
-| `cohort.updated` | Cohort Updated | Cohort criteria or settings were modified |
+| Event Type        | Display Name    | Description                               | Available Since      |
+| ----------------- | --------------- | ----------------------------------------- | -------------------- |
+| `cohort.created`  | Cohort Created  | A new cohort was created                  | 2026-04-03T19:00:00Z |
+| `cohort.deleted`  | Cohort Deleted  | A cohort was removed                      | 2026-04-03T19:00:00Z |
+| `cohort.shared`   | Cohort Shared   | A cohort was shared with users or teams   | 2026-04-03T19:00:00Z |
+| `cohort.unshared` | Cohort Unshared | Sharing access to a cohort was revoked    | 2026-04-03T19:00:00Z |
+| `cohort.updated`  | Cohort Updated  | Cohort criteria or settings were modified | 2026-04-03T19:00:00Z |
 
+### Cohort Syncs
+
+| Event Type            | Display Name        | Description                                  | Available Since      |
+| --------------------- | ------------------- | -------------------------------------------- | -------------------- |
+| `cohort_sync.created` | Cohort Sync Created | A new cohort sync integration was configured | 2026-05-18T19:00:00Z |
+| `cohort_sync.updated` | Cohort Sync Updated | Cohort sync settings were modified           | 2026-05-18T19:00:00Z |
 
 ### Data Pipelines
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `data_pipeline.created` | Data Pipeline Created | A new data pipeline integration was set up |
-| `data_pipeline.deleted` | Data Pipeline Deleted | A data pipeline was removed |
-| `data_pipeline.updated` | Data Pipeline Updated | Data pipeline configuration was modified |
+| Event Type              | Display Name          | Description                                | Available Since      |
+| ----------------------- | --------------------- | ------------------------------------------ | -------------------- |
+| `data_pipeline.created` | Data Pipeline Created | A new data pipeline integration was set up | 2026-04-03T19:00:00Z |
+| `data_pipeline.deleted` | Data Pipeline Deleted | A data pipeline was removed                | 2026-04-03T19:00:00Z |
+| `data_pipeline.updated` | Data Pipeline Updated | Data pipeline configuration was modified   | 2026-04-03T19:00:00Z |
 
 ### Warehouse Sources
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `warehouse_source.created` | Warehouse Source Created | A new warehouse data source was connected |
-| `warehouse_source.deleted` | Warehouse Source Deleted | A warehouse source connection was removed |
-| `warehouse_source.updated` | Warehouse Source Updated | Warehouse source configuration was changed |
+| Event Type                      | Display Name                  | Description                                      | Available Since      |
+| ------------------------------- | ----------------------------- | ------------------------------------------------ | -------------------- |
+| `warehouse_source.created`      | Warehouse Source Created      | A new warehouse data source was connected        | 2026-04-03T19:00:00Z |
+| `warehouse_source.deleted`      | Warehouse Source Deleted      | A warehouse source connection was removed        | 2026-04-03T19:00:00Z |
+| `warehouse_source.updated`      | Warehouse Source Updated      | Warehouse source configuration was changed       | 2026-04-03T19:00:00Z |
+| `warehouse_source_sync.created` | Warehouse Source Sync Created | A warehouse source sync job was created          | 2026-05-18T19:00:00Z |
+| `warehouse_source_sync.deleted` | Warehouse Source Sync Deleted | A warehouse source sync job was deleted          | 2026-05-18T19:00:00Z |
+| `warehouse_source_sync.updated` | Warehouse Source Sync Updated | Warehouse source sync configuration was modified | 2026-05-18T19:00:00Z |
 
 ### Data Management
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `event_deletion.canceled` | Event Deletion Canceled | A pending event deletion request was canceled |
-| `event_deletion.created` | Event Deletion Requested | A request to delete events was submitted |
-| `user_data_deletion.canceled` | User Data Deletion Canceled | A pending user data deletion request was canceled |
-| `user_data_deletion.created` | User Data Deletion Requested | A request to delete user profile data was submitted |
+| Event Type                    | Display Name                 | Description                                         | Available Since      |
+| ----------------------------- | ---------------------------- | --------------------------------------------------- | -------------------- |
+| `event_definition.created`    | Event Definition Created     | A new event definition was created                  | 2026-05-18T19:00:00Z |
+| `event_definition.deleted`    | Event Definition Deleted     | An event definition was deleted                     | 2026-05-18T19:00:00Z |
+| `event_definition.updated`    | Event Definition Updated     | An event definition was modified                    | 2026-05-18T19:00:00Z |
+| `event_deletion.canceled`     | Event Deletion Canceled      | A pending event deletion request was canceled       | 2026-04-03T19:00:00Z |
+| `event_deletion.created`      | Event Deletion Requested     | A request to delete events was submitted            | 2026-04-03T19:00:00Z |
+| `profile.deleted`             | Profile Deleted              | A user profile was removed                          | 2026-05-18T19:00:00Z |
+| `profile.updated`             | Profile Updated              | A user profile was updated                          | 2026-05-18T19:00:00Z |
+| `property_definition.created` | Property Definition Created  | A new property definition was created               | 2026-05-18T19:00:00Z |
+| `property_definition.updated` | Property Definition Updated  | A property definition was modified                  | 2026-05-18T19:00:00Z |
+| `user_data_deletion.canceled` | User Data Deletion Canceled  | A pending user data deletion request was canceled   | 2026-04-03T19:00:00Z |
+| `user_data_deletion.created`  | User Data Deletion Requested | A request to delete user profile data was submitted | 2026-04-03T19:00:00Z |
+
+> **Note:** Profile updates (`profile.deleted`, `profile.updated`) are only tracked when initiated through the Mixpanel web application. API calls and direct updates using the Mixpanel SDK are not currently logged in the audit log.
 
 ### Data Exports
 
-| Event Type | Display Name | Description |
-|------------|--------------|-------------|
-| `audit_log_export.created` | Audit Log Export Created | An audit log export was initiated |
-| `audit_log_export.downloaded` | Audit Log Export Downloaded | An audit log export file was downloaded |
-| `event_export.downloaded` | Events Exported | Event data was exported from the project |
-| `profile_export.downloaded` | Profile Data Exported | User profile data was exported |
-| `user_data_export.created` | User Data Export Requested | A user data export request was submitted |
+| Event Type                    | Display Name                | Description                              | Available Since      |
+| ----------------------------- | --------------------------- | ---------------------------------------- | -------------------- |
+| `audit_log_export.created`    | Audit Log Export Created    | An audit log export was initiated        | 2026-04-03T19:00:00Z |
+| `audit_log_export.downloaded` | Audit Log Export Downloaded | An audit log export file was downloaded  | 2026-04-03T19:00:00Z |
+| `event_export.downloaded`     | Events Exported             | Event data was exported from the project | 2026-04-03T19:00:00Z |
+| `profile_export.downloaded`   | Profile Data Exported       | User profile data was exported           | 2026-04-03T19:00:00Z |
+| `raw_event_export.requested`  | Raw Event Export Requested  | A raw event export was requested         | 2026-05-18T19:00:00Z |
+| `user_data_export.created`    | User Data Export Requested  | A user data export request was submitted | 2026-04-03T19:00:00Z |
 
 ### Service Accounts
 
-| Event Type | Display Name | Description | Scope |
-|------------|--------------|-------------|-------|
-| `service_account.created` | Service Account Created | A new service account was created | Organization only |
-| `service_account.deleted` | Service Account Deleted | A service account was removed | Organization only |
-| `service_account.added_to_project` | Service Account Added to Project | A service account was granted access to a project | Both |
-| `service_account.removed_from_project` | Service Account Removed from Project | A service account's project access was revoked | Both |
-| `service_account.role_changed` | Service Account Role Changed | A service account's role or permissions were modified | Both |
+| Event Type                             | Display Name                         | Description                                           | Scope             | Available Since      |
+| -------------------------------------- | ------------------------------------ | ----------------------------------------------------- | ----------------- | -------------------- |
+| `service_account.added_to_project`     | Service Account Added to Project     | A service account was granted access to a project     | Both              | 2026-04-03T19:00:00Z |
+| `service_account.created`              | Service Account Created              | A new service account was created                     | Organization only | 2026-04-03T19:00:00Z |
+| `service_account.deleted`              | Service Account Deleted              | A service account was removed                         | Organization only | 2026-04-03T19:00:00Z |
+| `service_account.removed_from_project` | Service Account Removed from Project | A service account's project access was revoked        | Both              | 2026-04-03T19:00:00Z |
+| `service_account.role_changed`         | Service Account Role Changed         | A service account's role or permissions were modified | Both              | 2026-04-03T19:00:00Z |
 
 ### User Authentication
 
-| Event Type | Display Name | Description | Scope |
-|------------|--------------|-------------|-------|
-| `session.logged_in` | User Logged In | A user successfully logged into the organization | Organization only |
-| `session.logged_out` | User Logged Out | A user logged out of the organization | Organization only |
-| `user.twofactor_enabled` | User Enabled Two-Factor Auth | A user activated two-factor authentication | Organization only |
+| Event Type               | Display Name                 | Description                                      | Scope             | Available Since      |
+| ------------------------ | ---------------------------- | ------------------------------------------------ | ----------------- | -------------------- |
+| `session.logged_in`      | User Logged In               | A user successfully logged into the organization | Organization only | 2026-04-03T19:00:00Z |
+| `session.logged_out`     | User Logged Out              | A user logged out of the organization            | Organization only | 2026-04-03T19:00:00Z |
+| `session.login_failed`   | User Login Failed            | A user login attempt failed                      | Organization only | 2026-05-18T19:00:00Z |
+| `user.twofactor_enabled` | User Enabled Two-Factor Auth | A user activated two-factor authentication       | Organization only | 2026-04-03T19:00:00Z |
+
+### Billing Info
+
+| Event Type                                 | Display Name                        | Description                              | Scope             | Available Since      |
+| ------------------------------------------ | ----------------------------------- | ---------------------------------------- | ----------------- | -------------------- |
+| `billing_info.payment_info_updated`        | Billing Payment Information Updated | Billing payment information was modified | Organization only | 2026-05-18T19:00:00Z |
+| `billing_info.receipt_preferences_updated` | Billing Invoice Preferences Updated | Billing invoice preferences were updated | Organization only | 2026-05-18T19:00:00Z |
+| `billing_info.tax_info_updated`            | Billing Tax Information Updated     | Billing tax information was modified     | Organization only | 2026-05-18T19:00:00Z |
+
+### Experiments
+
+| Event Type              | Display Name                 | Description                          | Available Since      |
+| ----------------------- | ---------------------------- | ------------------------------------ | -------------------- |
+| `experiment.archived`   | Experiment Archived          | An experiment was archived           | 2026-05-18T19:00:00Z |
+| `experiment.concluded`  | Experiment Concluded         | An experiment was concluded          | 2026-05-18T19:00:00Z |
+| `experiment.created`    | Experiment Created           | A new experiment was created         | 2026-05-18T19:00:00Z |
+| `experiment.decided`    | Experiment Decision Recorded | A decision was made on an experiment | 2026-05-18T19:00:00Z |
+| `experiment.deleted`    | Experiment Deleted           | An experiment was deleted            | 2026-05-18T19:00:00Z |
+| `experiment.duplicated` | Experiment Duplicated        | An experiment was duplicated         | 2026-05-18T19:00:00Z |
+| `experiment.launched`   | Experiment Launched          | An experiment was launched           | 2026-05-18T19:00:00Z |
+| `experiment.restored`   | Experiment Restored          | An archived experiment was restored  | 2026-05-18T19:00:00Z |
+| `experiment.updated`    | Experiment Updated           | Experiment settings were modified    | 2026-05-18T19:00:00Z |
+
+### Feature Flags
+
+| Event Type                | Display Name            | Description                           | Available Since      |
+| ------------------------- | ----------------------- | ------------------------------------- | -------------------- |
+| `feature_flag.archived`   | Feature Flag Archived   | A feature flag was archived           | 2026-05-18T19:00:00Z |
+| `feature_flag.created`    | Feature Flag Created    | A new feature flag was created        | 2026-05-18T19:00:00Z |
+| `feature_flag.deleted`    | Feature Flag Deleted    | A feature flag was deleted            | 2026-05-18T19:00:00Z |
+| `feature_flag.duplicated` | Feature Flag Duplicated | A feature flag was duplicated         | 2026-05-18T19:00:00Z |
+| `feature_flag.restored`   | Feature Flag Restored   | An archived feature flag was restored | 2026-05-18T19:00:00Z |
+| `feature_flag.updated`    | Feature Flag Updated    | Feature flag settings were modified   | 2026-05-18T19:00:00Z |
+
+### Organization Settings
+
+| Event Type                                        | Display Name                          | Description                                              | Scope             | Available Since      |
+| ------------------------------------------------- | ------------------------------------- | -------------------------------------------------------- | ----------------- | -------------------- |
+| `organization_access_security.twofactor_disabled` | Organization Two-Factor Auth Disabled | Organization-wide two-factor authentication was disabled | Organization only | 2026-05-18T19:00:00Z |
+| `organization_access_security.twofactor_enabled`  | Organization Two-Factor Auth Enabled  | Organization-wide two-factor authentication was enabled  | Organization only | 2026-05-18T19:00:00Z |
+| `organization_setting.updated`                    | Organization Settings Changed         | Organization settings were modified                      | Organization only | 2026-05-18T19:00:00Z |
+| `organization_spark_setting.updated`              | Organization AI Settings Changed      | Organization AI settings were updated                    | Organization only | 2026-05-18T19:00:00Z |
+
+### Project Settings
+
+| Event Type            | Display Name        | Description                                                    | Available Since      |
+| --------------------- | ------------------- | -------------------------------------------------------------- | -------------------- |
+| `project.transferred` | Project Transferred | A project was transferred to a different organization or owner | 2026-05-18T19:00:00Z |
+
+### Teams
+
+| Event Type                     | Display Name                      | Description                               | Scope             | Available Since      |
+| ------------------------------ | --------------------------------- | ----------------------------------------- | ----------------- | -------------------- |
+| `team.created`                 | Team Created                      | A new team was created                    | Organization only | 2026-05-18T19:00:00Z |
+| `team.deleted`                 | Team Deleted                      | A team was deleted                        | Organization only | 2026-05-18T19:00:00Z |
+| `team.service_account_added`   | Service Account Added to Team     | A service account was added to a team     | Organization only | 2026-05-18T19:00:00Z |
+| `team.service_account_removed` | Service Account Removed from Team | A service account was removed from a team | Organization only | 2026-05-18T19:00:00Z |
+| `team.updated`                 | Team Updated                      | Team settings were modified               | Organization only | 2026-05-18T19:00:00Z |
+| `team.user_added`              | User Added to Team                | A user was added to a team                | Organization only | 2026-05-18T19:00:00Z |
+| `team.user_removed`            | User Removed from Team            | A user was removed from a team            | Organization only | 2026-05-18T19:00:00Z |
+
+### User Management
+
+| Event Type                       | Display Name                   | Description                                           | Scope             | Available Since      |
+| -------------------------------- | ------------------------------ | ----------------------------------------------------- | ----------------- | -------------------- |
+| `invitation.accepted`            | Accepted Invitation            | A user accepted an invitation to the organization     | Organization only | 2026-05-18T19:00:00Z |
+| `invitation.sent`                | Invited User to Organization   | An invitation was sent to a new user                  | Organization only | 2026-05-18T19:00:00Z |
+| `organization.user_added`        | User Added to Organization     | A user was added to the organization                  | Organization only | 2026-05-18T19:00:00Z |
+| `organization.user_removed`      | User Removed from Organization | A user was removed from the organization              | Organization only | 2026-05-18T19:00:00Z |
+| `project.default_access_granted` | Default Project Access Granted | Default access for all users to a project was granted | Both              | 2026-05-18T19:00:00Z |
+| `project.default_access_revoked` | Default Project Access Revoked | Default access for all users to a project was revoked | Both              | 2026-05-18T19:00:00Z |
+| `project.team_added`             | Team Added to Project          | A team was granted access to a project                | Both              | 2026-05-18T19:00:00Z |
+| `project.team_removed`           | Team Removed from Project      | A team's project access was revoked                   | Both              | 2026-05-18T19:00:00Z |
+| `project.user_added`             | User Added to Project          | A user was granted access to a project                | Both              | 2026-05-18T19:00:00Z |
+| `project.user_removed`           | User Removed from Project      | A user's project access was revoked                   | Both              | 2026-05-18T19:00:00Z |
+| `user.role_changed`              | User Role Changed              | A user's role or permissions were modified            | Both              | 2026-05-18T19:00:00Z |
+
+### Workspaces
+
+| Event Type               | Display Name                | Description                              | Available Since      |
+| ------------------------ | --------------------------- | ---------------------------------------- | -------------------- |
+| `workspace.team_added`   | Team Added to Data View     | A team was granted access to a data view | 2026-05-18T19:00:00Z |
+| `workspace.team_removed` | Team Removed from Data View | A team's data view access was revoked    | 2026-05-18T19:00:00Z |
+| `workspace.user_added`   | User Added to Data View     | A user was granted access to a data view | 2026-05-18T19:00:00Z |
+| `workspace.user_removed` | User Removed from Data View | A user's data view access was revoked    | 2026-05-18T19:00:00Z |
 
 ## Exporting Audit Log
 


### PR DESCRIPTION
**Note: Final list and date of audit log types for release is not completely finalized.**

Adds documentation for all new to-be-released audit log types.

Rather than a precise UTC timestamp for event release, I've updated with "available since" to the first full date with global coverage for readability & simplicity. e.g., if we release at May 18th at 12:00 PM PDT, a full day of audit logs is available globally starting May 20th.