### PR TITLE
[Exp / FF]  Docs for Multi Environment Selector

### DIFF
--- a/pages/docs/experiments.mdx
+++ b/pages/docs/experiments.mdx
@@ -256,6 +256,40 @@ Click 'Analyze' on a metric to dive deeper into the results. This will open a no
 You can also add the experiment breakdowns and filters directly in a report via the Experiments tab in the query builder. This lets you do on-the-fly analysis with the experiment groups. Under the hood, the experiment breakdown and filter work the same as the Experiment report.
 
 
+
+## Multiple Environments
+
+### Other Environments Selector
+
+The "Other Environments" selector will appear under the "Settings" tab of a feature flag. This panel allows the user
+to manage changes between Experiments across different projects. This enables users to use a Mixpanel project as a development environments
+where they can create and make changes to an experiment, and select another project to push those changes to.
+
+#### Pushing changes
+When pushing changes to a linked experiment, the source experiment will push all info to the destination flag. All other changes on the destination experiment will
+be overwritten.
+
+#### Other Environments Menu
+
+This menu displays a list of the linked experiment that exist in other projects. From here, you can manage the other experiments. This menu allows you
+to navigate to the linked experiment, push changes that have occurred to the linked experiment, or remove the connection.
+
+#### Duplicate To Project
+
+A user can duplicate an experiment to other projects. You may not use this experiment for duplicating to the same project (use the existing duplicate flow instead).
+Once a user has duplicated an experiment to another project, they will be able to manage the connection from within the "Other Environments" menu.
+
+#### Feature Flags
+
+If an experiment is linked to a Mixpanel Feature Flag, you can manage both from within the Experiments "Other Environments" menu.
+
+When duplicating an experiment that is linked to a Mixpanel Flag to another project, you will be prompted to confirm whether or not you
+would also like to duplicate the linked flag. If you choose to do so, the new experiment will be linked to the new flag. The new flag will
+also appear in the "Other Environments" menu for the original flag; they will be linked.
+
+When pushing changes to a project, if both the destination and source experiments are linked to flags that are ALSO linked, (i.e. you choose
+to duplicate the flag as well), you may choose to push any changes that have occurred in the source flag to the destination projects flag.
+
 ## Advanced Statistical Methods
 
 Mixpanel offers several advanced statistical options to help you get more reliable experiment results. These features address common challenges in experimentation: controlling for multiple comparisons, handling outliers, validating experiment setup, and reducing variance to reach significance faster.

--- a/pages/docs/featureflags.mdx
+++ b/pages/docs/featureflags.mdx
@@ -372,6 +372,33 @@ The Feature Flags tab on a user's profile page will display the most recently vi
 If a user later sees a new variant, that will be displayed instead. If the flag is tied to an experiment, clicking on the right arrow will open a menu allowing the user to navigate
 to the feature flag page of the associated flag, or the related experiment page.
 
+## Multiple Environments
+
+### Other Environments Selector
+
+The "Other Environments" selector will appear under the "Settings" tab of a feature flag. This panel allows the user
+to manage changes between Feature Flags across different projects. This enables users to use a Mixpanel project as a development environments
+where they can create and make changes to a flag, and select another project to push those changes to.
+
+#### Pushing changes
+When pushing changes to a linked flag, the source flag will push all info to the destination flag. All other changes on the destination flag will
+be overwritten.
+
+#### Other Environments Menu
+
+This menu displays a list of the linked feature flags that exist in other projects. From here, you can manage the other flags. This menu allows you
+to navigate to the linked flag, push changes that have occurred to the linked flag, or remove the connection.
+
+#### Duplicate To Project
+
+A user can duplicate a feature flag to other projects. You may not use this feature for duplicating to the same project (use the existing duplicate flow instead).
+Once a user has duplicated a flag to another project, they will be able to manage the connection from within the "Other Environments" menu.
+
+#### Data Groups
+
+Feature Flag rollouts may include configuration that reference data groups in a given project. For instance, if the user changes the
+"Assignment Key" of a flag, both the source and destination projects _must_ include the referenced data group in order to duplicate or push changes.
+If the assignment key is _not_ present in the destination project, the operations will fail.
 
 ## Feature Flagging Pricing FAQ
 


### PR DESCRIPTION
Updates the docs for the "Other Environments" selector in Experiment and Feature Flags.

Currently exists in p3 or for users with the `content-multi-environment-selector` feature flag in their headers